### PR TITLE
Fix admin project access

### DIFF
--- a/backend/src/controllers/analytics.ts
+++ b/backend/src/controllers/analytics.ts
@@ -10,6 +10,7 @@ const DISABLE_CACHE = true;
 export const getVisitStats = async (req: Request, res: Response) => {
   const projectId = req.currentProjectId;
   const userId = req.user?.id;
+  const isAdmin = req.user?.role === "ADMIN";
 
   // Security check: ensure we have either a project ID or a user ID
   if (!projectId && !userId) {
@@ -54,7 +55,7 @@ export const getVisitStats = async (req: Request, res: Response) => {
       whereClause.linkId = parseInt(linkId as string);
       whereClause.link = {
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
           ...(projectId && { id: parseInt(projectId as string) }),
         },
       };
@@ -63,14 +64,14 @@ export const getVisitStats = async (req: Request, res: Response) => {
       whereClause.link = {
         projectId: parseInt(projectId as string),
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       };
     } else {
       // Filtrer par tous les projets de l'utilisateur
       whereClause.link = {
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       };
     }
@@ -134,7 +135,8 @@ export const getVisitStats = async (req: Request, res: Response) => {
       projectId ? parseInt(projectId as string) : null,
       linkId ? parseInt(linkId as string) : null,
       timeRange,
-      parseInt(`${userId}`)
+      parseInt(`${userId}`),
+      isAdmin
     );
 
     // Si linkId est spécifié, ajouter les statistiques par règles
@@ -205,13 +207,14 @@ async function getVisitsByTimeInterval(
   projectId: number | null = null,
   linkId: number | null = null,
   timeRange: string = "week",
-  userId: number // Changer le type en number
+  userId: number,
+  isAdmin: boolean = false
 ): Promise<Array<{ date: string; count: number }>> {
   try {
     const whereClause: any = {
       link: {
         project: {
-          userId: userId, // userId est maintenant un nombre
+          ...(isAdmin ? {} : { userId }),
         },
       },
     };
@@ -313,17 +316,18 @@ export const getDashboardStats = async (req: Request, res: Response) => {
 
   try {
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     // Construire la clause where commune
     const baseWhereClause = projectId
       ? { link: { projectId: Number(projectId) } }
-      : { link: { project: { userId } } };
+      : { link: { project: isAdmin ? {} : { userId } } };
 
     // Obtenir le nombre total de liens
     const totalLinks = await prisma.link.count({
       where: projectId
         ? { projectId: Number(projectId) }
-        : { project: { userId } },
+        : { project: isAdmin ? {} : { userId } },
     });
 
     // Obtenir le nombre total de visites

--- a/backend/src/controllers/link.ts
+++ b/backend/src/controllers/link.ts
@@ -48,6 +48,7 @@ export const getLinksByProject = async (req: Request, res: Response) => {
   try {
     const { projectId } = req.params;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 10;
     let sortBy = (req.query.sortBy as string) || "createdAt";
@@ -94,7 +95,7 @@ export const getLinksByProject = async (req: Request, res: Response) => {
     const project = await prisma.project.findFirst({
       where: {
         id: parseInt(projectId),
-        userId: userId,
+        ...(isAdmin ? {} : { userId: userId }),
       },
     });
     console.log(
@@ -313,12 +314,13 @@ export const getLinkById = async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const link = await prisma.link.findFirst({
       where: {
         id: parseInt(id),
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       },
       include: {
@@ -359,12 +361,13 @@ export const updateLink = async (req: Request, res: Response) => {
       utmContent,
     } = req.body;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const link = await prisma.link.findFirst({
       where: {
         id: parseInt(id),
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       },
     });
@@ -500,12 +503,13 @@ export const deleteLink = async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const link = await prisma.link.findFirst({
       where: {
         id: parseInt(id),
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       },
     });
@@ -539,12 +543,13 @@ export const addRule = async (req: Request, res: Response) => {
     const { linkId } = req.params;
     const { redirectUrl, countries } = req.body;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const link = await prisma.link.findFirst({
       where: {
         id: parseInt(linkId),
         project: {
-          userId: userId,
+          ...(isAdmin ? {} : { userId: userId }),
         },
       },
     });
@@ -577,13 +582,14 @@ export const updateRule = async (req: Request, res: Response) => {
     const { ruleId } = req.params;
     const { redirectUrl, countries } = req.body;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const rule = await prisma.linkRule.findFirst({
       where: {
         id: parseInt(ruleId),
         link: {
           project: {
-            userId: userId,
+            ...(isAdmin ? {} : { userId: userId }),
           },
         },
       },
@@ -617,13 +623,14 @@ export const deleteRule = async (req: Request, res: Response) => {
   try {
     const { ruleId } = req.params;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
 
     const rule = await prisma.linkRule.findFirst({
       where: {
         id: parseInt(ruleId),
         link: {
           project: {
-            userId: userId,
+            ...(isAdmin ? {} : { userId: userId }),
           },
         },
       },
@@ -690,6 +697,7 @@ export const getLinkStats = async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
     const timeRange = (req.query.timeRange as string) || "week";
     const startDate = req.query.startDate
       ? new Date(req.query.startDate as string)
@@ -706,7 +714,7 @@ export const getLinkStats = async (req: Request, res: Response) => {
       where: {
         id: parseInt(id),
         project: {
-          userId,
+          ...(isAdmin ? {} : { userId }),
         },
       },
     });

--- a/backend/src/controllers/user.ts
+++ b/backend/src/controllers/user.ts
@@ -359,6 +359,7 @@ export const updateTheme = async (req: Request, res: Response) => {
 export const updateLastProjectId = async (req: Request, res: Response) => {
   try {
     const userId = req.user?.id;
+    const isAdmin = req.user?.role === "ADMIN";
     const { projectId } = req.body;
 
     if (!userId) {
@@ -373,7 +374,7 @@ export const updateLastProjectId = async (req: Request, res: Response) => {
     const project = await prisma.project.findFirst({
       where: {
         id: projectId,
-        userId: userId,
+        ...(isAdmin ? {} : { userId: userId }),
       },
     });
 

--- a/backend/src/middleware/projectAccess.ts
+++ b/backend/src/middleware/projectAccess.ts
@@ -8,6 +8,8 @@ export const validateProjectAccess = async (
 ) => {
   try {
     const userId = req.user?.id;
+    const role = req.user?.role;
+    const isAdmin = role === "ADMIN";
     const projectId =
       req.currentProjectId ||
       req.params.projectId ||
@@ -25,7 +27,7 @@ export const validateProjectAccess = async (
     const project = await prisma.project.findFirst({
       where: {
         id: parseInt(projectId as string),
-        userId: userId,
+        ...(isAdmin ? {} : { userId: userId }),
       },
     });
 


### PR DESCRIPTION
## Summary
- allow admins to access any project in `validateProjectAccess`
- relax user checks for admins in link, analytics and user controllers

## Testing
- `npm test` *(fails: Password Protection Middleware and Redirection Service tests)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684985b6c5c8832b9be039de29b6841a