### PR TITLE
Add cookie-parser middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "cheerio": "^1.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
+    "cookie-parser": "^1.4.6",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
     "he": "^1.2.0",
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
+    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^4.17.21",
     "@types/he": "^1.2.3",
     "@types/jest": "^29.5.14",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import express, { Application, NextFunction, Request, Response } from "express";
 import analyticsRoutes from "./routes/analytics";
 import cors from "cors";
 import dotenv from "dotenv";
+import cookieParser from "cookie-parser";
 import { errorHandler } from "./middleware/errorHandler";
 import { handleRedirection } from "./controllers/link";
 import helmet from "helmet";
@@ -65,6 +66,7 @@ app.use(
 app.use(morgan(morganFormat)); // Logging avancé
 app.use(cors()); // CORS
 app.use(express.json()); // Parse JSON bodies
+app.use(cookieParser());
 
 // Middleware de logging pour toutes les requêtes
 app.use((req: Request, _res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Summary
- install `cookie-parser` with type definitions
- initialize cookie parsing in Express app

## Testing
- `npm test --prefix backend` *(fails: Redirection Service Tests and Password Protection Middleware)*

------
https://chatgpt.com/codex/tasks/task_e_685e8915d73c832ba2dc45517a495f05