### PR TITLE
Use parameterized Prisma query in link stats

### DIFF
--- a/backend/src/controllers/link.ts
+++ b/backend/src/controllers/link.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { deleteFromCache, getFromCache, saveToCache } from "../lib/redis";
 
 import prisma from "../lib/prisma";
+import { Prisma } from "@prisma/client";
 
 // Function to generate a random short code
 const generateRandomCode = (length: number = 4): string => {
@@ -815,43 +816,41 @@ export const getLinkStats = async (req: Request, res: Response) => {
       }
     );
 
-    // Obtenir les données de séries temporelles
-    const timeSeriesQuery = `
+    // Obtenir les données de séries temporelles avec requête paramétrée
+    const dateFormat =
+      timeRange === "day"
+        ? "%Y-%m-%d %H:00:00"
+        : timeRange === "week" || timeRange === "month"
+          ? "%Y-%m-%d"
+          : "%Y-%m";
+
+    let conditions = Prisma.sql``;
+    if (whereClause.createdAt?.gte) {
+      conditions = Prisma.sql`${conditions} AND createdAt >= ${whereClause.createdAt.gte}`;
+    }
+    if (whereClause.createdAt?.lte) {
+      conditions = Prisma.sql`${conditions} AND createdAt <= ${whereClause.createdAt.lte}`;
+    }
+    if (whereClause.country?.in) {
+      const countryList = Prisma.join(
+        whereClause.country.in.map((c: string) => Prisma.sql`${c}`),
+        ","
+      );
+      conditions = Prisma.sql`${conditions} AND country IN (${countryList})`;
+    }
+
+    const timeSeriesQuery = Prisma.sql`
       SELECT
-        DATE_FORMAT(createdAt, '${
-          timeRange === "day"
-            ? "%Y-%m-%d %H:00:00"
-            : timeRange === "week"
-              ? "%Y-%m-%d"
-              : timeRange === "month"
-                ? "%Y-%m-%d"
-                : "%Y-%m"
-        }') as date,
+        DATE_FORMAT(createdAt, ${Prisma.raw(dateFormat)}) as date,
         COUNT(*) as count
       FROM LinkVisit
       WHERE linkId = ${parseInt(id)}
-        ${
-          whereClause.createdAt?.gte
-            ? `AND createdAt >= '${whereClause.createdAt.gte.toISOString()}'`
-            : ""
-        }
-        ${
-          whereClause.createdAt?.lte
-            ? `AND createdAt <= '${whereClause.createdAt.lte.toISOString()}'`
-            : ""
-        }
-        ${
-          whereClause.country?.in
-            ? `AND country IN (${whereClause.country.in
-                .map((c: string) => `'${c}'`)
-                .join(",")})`
-            : ""
-        }
+      ${conditions}
       GROUP BY date
       ORDER BY date ASC
     `;
 
-    const timeSeries = await prisma.$queryRawUnsafe(timeSeriesQuery);
+    const timeSeries = await prisma.$queryRaw(timeSeriesQuery);
 
     return res.json({
       message: "Statistiques du lien récupérées avec succès",

--- a/backend/tests/controllers/linkStats.test.ts
+++ b/backend/tests/controllers/linkStats.test.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from "express";
+import { getLinkStats } from "../../src/controllers/link";
+import prisma from "../../src/lib/prisma";
+import { createMockResponse } from "../utils/testHelpers";
+
+describe("getLinkStats SQL injection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("sanitizes malicious input", async () => {
+    const req = {
+      params: { id: "1; DROP TABLE LinkVisit;" },
+      query: { countries: "US'); DROP TABLE LinkVisit; --" },
+      user: { id: 1, role: "ADMIN" },
+    } as unknown as Request;
+    const res = createMockResponse() as Response;
+
+    (prisma.link.findFirst as any).mockResolvedValue({ id: 1 });
+    (prisma.linkVisit.count as any).mockResolvedValue(0);
+    (prisma.linkVisit.groupBy as any).mockResolvedValue([]);
+    (prisma.linkRule.findMany as any).mockResolvedValue([]);
+    (prisma.$queryRaw as any).mockResolvedValue([]);
+
+    await getLinkStats(req, res);
+
+    expect(prisma.$queryRaw).toHaveBeenCalled();
+    const arg = (prisma.$queryRaw as jest.Mock).mock.calls[0][0] as any;
+    expect(typeof arg).toBe("object");
+    expect(arg.sql).not.toMatch(/DROP TABLE/);
+  });
+});


### PR DESCRIPTION
## Summary
- switch link stats time series query to `Prisma.sql`
- add regression test ensuring malicious input doesn't break the query

## Testing
- `npm test` *(fails: mockFn.mockReturnThis is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_685e8913cf20832ba126d113ab4bc063