### PR TITLE
Add chrome extension for quick link creation

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,0 +1,11 @@
+# rflnk Chrome Extension
+
+This extension allows you to create rflnk links without visiting rflnk.com.
+
+## Features
+- Uses the authentication token from rflnk.com automatically when available.
+- Login directly from the popup if no token is found.
+- Create links from the popup form or by selecting text and using the context menu.
+- Copies the generated short link to your clipboard and shows a notification.
+
+Load the `chrome-extension` folder as an unpacked extension in Chrome.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,71 @@
+const API_URL = 'https://rflnk.com/api';
+
+function getStored(key) {
+  return new Promise(resolve => {
+    chrome.storage.local.get(key, result => resolve(result[key]));
+  });
+}
+
+function setStored(obj) {
+  return new Promise(resolve => {
+    chrome.storage.local.set(obj, resolve);
+  });
+}
+
+async function apiRequest(endpoint, method, data) {
+  const token = await getStored('token');
+  const projectId = await getStored('projectId');
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (projectId) headers['X-Project-ID'] = String(projectId);
+
+  const res = await fetch(API_URL + endpoint, {
+    method,
+    headers,
+    body: data ? JSON.stringify(data) : undefined
+  });
+  if (!res.ok) throw new Error('API error');
+  const json = await res.json();
+  return json.data;
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'create-link',
+    title: 'Create rflnk from selection',
+    contexts: ['selection']
+  });
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId === 'create-link' && info.selectionText) {
+    try {
+      const link = await apiRequest('/links', 'POST', {
+        name: info.selectionText,
+        baseUrl: info.selectionText,
+        shortCode: ''
+      });
+      const url = `https://rflnk.com/l/${link.shortCode}`;
+      await navigator.clipboard.writeText(url);
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl: '',
+        title: 'rflnk',
+        message: 'Link created and copied!'
+      });
+    } catch (e) {
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl: '',
+        title: 'rflnk',
+        message: 'Failed to create link'
+      });
+    }
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'SET_TOKEN') {
+    setStored({ token: message.token });
+  }
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,10 @@
+(function(){
+  try {
+    const token = localStorage.getItem('auth_token');
+    if (token) {
+      chrome.runtime.sendMessage({type: 'SET_TOKEN', token});
+    }
+  } catch (e) {
+    console.error('rflnk extension token error', e);
+  }
+})();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "rflnk Quick Link",
+  "version": "0.1.0",
+  "description": "Create rflnk links directly from your browser.",
+  "permissions": ["storage", "activeTab", "scripting", "contextMenus", "clipboardWrite", "notifications"],
+  "host_permissions": ["https://rflnk.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://rflnk.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>rflnk</title>
+  <style>
+    body { font-family: sans-serif; padding: 10px; width: 300px; }
+    input, button { width: 100%; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <div id="login">
+    <input id="email" type="email" placeholder="Email" />
+    <input id="password" type="password" placeholder="Password" />
+    <button id="loginBtn">Login</button>
+  </div>
+  <div id="create" style="display:none">
+    <input id="name" placeholder="Link name" />
+    <input id="url" placeholder="Destination URL" />
+    <button id="createBtn">Create Link</button>
+  </div>
+  <div id="result" style="display:none"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,70 @@
+const API_URL = 'https://rflnk.com/api';
+
+function getStored(key) {
+  return new Promise(resolve => chrome.storage.local.get(key, r => resolve(r[key])));
+}
+function setStored(obj) {
+  return new Promise(resolve => chrome.storage.local.set(obj, resolve));
+}
+
+async function apiRequest(endpoint, method, data) {
+  const token = await getStored('token');
+  const projectId = await getStored('projectId');
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (projectId) headers['X-Project-ID'] = String(projectId);
+  const res = await fetch(API_URL + endpoint, {
+    method,
+    headers,
+    body: data ? JSON.stringify(data) : undefined
+  });
+  if (!res.ok) throw new Error('API error');
+  const json = await res.json();
+  return json.data;
+}
+
+function showCreate() {
+  document.getElementById('login').style.display = 'none';
+  document.getElementById('create').style.display = 'block';
+}
+
+async function init() {
+  const token = await getStored('token');
+  if (token) showCreate();
+
+  document.getElementById('loginBtn').onclick = async () => {
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    try {
+      const res = await fetch(API_URL + '/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error();
+      await setStored({ token: json.data.token });
+      const projects = await apiRequest('/projects', 'GET');
+      if (projects.length) await setStored({ projectId: projects[0].id });
+      showCreate();
+    } catch (e) {
+      alert('Login failed');
+    }
+  };
+
+  document.getElementById('createBtn').onclick = async () => {
+    const name = document.getElementById('name').value;
+    const url = document.getElementById('url').value;
+    try {
+      const link = await apiRequest('/links', 'POST', { name, baseUrl: url, shortCode: '' });
+      const shortUrl = `https://rflnk.com/l/${link.shortCode}`;
+      document.getElementById('result').textContent = shortUrl;
+      document.getElementById('result').style.display = 'block';
+      await navigator.clipboard.writeText(shortUrl);
+    } catch (e) {
+      alert('Failed to create link');
+    }
+  };
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a `chrome-extension` folder with manifest v3
- background script manages context menu and token
- content script grabs auth token from rflnk.com
- popup allows login and link creation
- documentation for the extension

## Testing
- `npm test --silent` *(fails: expect jest.fn etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685e8d879038832bb634ea5404a51cf2