### PR TITLE
feat: add api key authentication and management

### DIFF
--- a/backend/prisma/migrations/20250412000000_add_api_keys/migration.sql
+++ b/backend/prisma/migrations/20250412000000_add_api_keys/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE `ApiKey` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `key` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    UNIQUE INDEX `ApiKey_key_key`(`key`),
+    INDEX `ApiKey_userId_idx`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `ApiKey` ADD CONSTRAINT `ApiKey_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
     theme          String?   @default("system") // Added theme preference
     lastProjectId  Int? // Added to store the last selected project
     projects       Project[]
+    apiKeys        ApiKey[]
     createdAt      DateTime  @default(now())
     updatedAt      DateTime  @updatedAt
 }
@@ -125,6 +126,15 @@ model LinkVisit {
     @@index([ip])
     @@index([ruleId])
     @@index([deviceRuleId])
+}
+
+model ApiKey {
+    id        Int      @id @default(autoincrement())
+    name      String
+    key       String   @unique
+    user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId    Int
+    createdAt DateTime @default(now())
 }
 
 enum Role {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import metadataRoutes from "./routes/metadata";
 import morgan from "morgan";
 import path from "path";
 import projectRoutes from "./routes/project";
+import apiKeyRoutes from "./routes/apiKey";
 import rateLimit from "express-rate-limit";
 import userRoutes from "./routes/user";
 
@@ -90,6 +91,7 @@ app.use("/api/links", linkRoutes);
 app.use("/api/analytics", analyticsRoutes);
 app.use("/api/projects", projectRoutes);
 app.use("/api/metadata", metadataRoutes);
+app.use("/api/api-keys", apiKeyRoutes);
 
 // Chemin vers le build de l'application React
 const frontendBuildPath = path.resolve(__dirname, "../../frontend/dist");

--- a/backend/src/controllers/apiKey.ts
+++ b/backend/src/controllers/apiKey.ts
@@ -1,0 +1,81 @@
+import { Request, Response } from "express";
+import { ApiResponse } from "../types";
+import prisma from "../lib/prisma";
+import { randomBytes } from "crypto";
+
+export const listApiKeys = async (req: Request, res: Response) => {
+  try {
+    const keys = await prisma.apiKey.findMany({
+      where: { userId: req.user!.id },
+      select: {
+        id: true,
+        name: true,
+        key: true,
+        createdAt: true,
+      },
+    });
+
+    const response: ApiResponse = {
+      message: "Clés API récupérées avec succès",
+      data: keys,
+    };
+
+    res.json(response);
+  } catch (error) {
+    res.status(500).json({ message: "Erreur lors de la récupération des clés API", error });
+  }
+};
+
+export const createApiKey = async (req: Request, res: Response) => {
+  try {
+    const { name } = req.body;
+    const key = randomBytes(32).toString("hex");
+
+    const apiKey = await prisma.apiKey.create({
+      data: {
+        name,
+        key,
+        userId: req.user!.id,
+      },
+      select: {
+        id: true,
+        name: true,
+        key: true,
+        createdAt: true,
+      },
+    });
+
+    const response: ApiResponse = {
+      message: "Clé API créée avec succès",
+      data: apiKey,
+    };
+
+    res.status(201).json(response);
+  } catch (error) {
+    res.status(500).json({ message: "Erreur lors de la création de la clé API", error });
+  }
+};
+
+export const deleteApiKey = async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const existing = await prisma.apiKey.findFirst({
+      where: { id, userId: req.user!.id },
+    });
+
+    if (!existing) {
+      res.status(404).json({ message: "Clé API introuvable" });
+      return;
+    }
+
+    await prisma.apiKey.delete({ where: { id } });
+
+    const response: ApiResponse = {
+      message: "Clé API supprimée avec succès",
+    };
+
+    res.json(response);
+  } catch (error) {
+    res.status(500).json({ message: "Erreur lors de la suppression de la clé API", error });
+  }
+};

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 
 import jwt from "jsonwebtoken";
+import prisma from "../lib/prisma";
 
 // Étendre l'interface Request pour inclure l'utilisateur
 declare global {
@@ -16,11 +17,38 @@ declare global {
 }
 
 // Middleware pour vérifier le JWT
-export const authenticateJWT = (
+export const authenticateJWT = async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
+  const apiKey = req.headers["x-api-key"] as string | undefined;
+
+  if (apiKey) {
+    try {
+      const keyRecord = await prisma.apiKey.findUnique({
+        where: { key: apiKey },
+        include: { user: true },
+      });
+
+      if (keyRecord && keyRecord.user) {
+        req.user = {
+          id: keyRecord.userId,
+          email: keyRecord.user.email,
+          role: keyRecord.user.role,
+        };
+        next();
+        return;
+      }
+
+      return res.status(401).json({
+        message: "Accès non autorisé. API key invalide",
+      });
+    } catch (error) {
+      return res.status(500).json({ message: "Erreur serveur" });
+    }
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader) {
     return res.status(401).json({

--- a/backend/src/routes/apiKey.ts
+++ b/backend/src/routes/apiKey.ts
@@ -1,0 +1,11 @@
+import express from "express";
+import { authenticateJWT } from "../middleware/auth";
+import { createApiKey, deleteApiKey, listApiKeys } from "../controllers/apiKey";
+
+const router = express.Router();
+
+router.get("/", authenticateJWT, listApiKeys);
+router.post("/", authenticateJWT, createApiKey);
+router.delete("/:id", authenticateJWT, deleteApiKey);
+
+export default router;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import GeneralSettings from "./settings/GeneralSettings";
 import NotificationSettings from "./settings/NotificationSettings";
 import ProfileSettings from "./settings/ProfileSettings";
 import SecuritySettings from "./settings/SecuritySettings";
+import ApiKeysSettings from "./settings/ApiKeysSettings";
 import { useState } from "react";
 
 export default function SettingsPage() {
@@ -25,6 +26,7 @@ export default function SettingsPage() {
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="security">Security</TabsTrigger>
           <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="api-keys">API Keys</TabsTrigger>
         </TabsList>
 
         <TabsContent value="general">
@@ -41,6 +43,10 @@ export default function SettingsPage() {
 
         <TabsContent value="notifications">
           <NotificationSettings />
+        </TabsContent>
+
+        <TabsContent value="api-keys">
+          <ApiKeysSettings />
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/pages/settings/ApiKeysSettings.tsx
+++ b/frontend/src/pages/settings/ApiKeysSettings.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { apiKeyService, ApiKey } from "@/services/apiKeyService";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export default function ApiKeysSettings() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [name, setName] = useState("");
+
+  const loadKeys = async () => {
+    try {
+      const data = await apiKeyService.list();
+      setKeys(data);
+    } catch (error) {
+      console.error("Error fetching API keys:", error);
+    }
+  };
+
+  useEffect(() => {
+    loadKeys();
+  }, []);
+
+  const handleCreate = async () => {
+    if (!name.trim()) return;
+    try {
+      const key = await apiKeyService.create(name);
+      setKeys((prev) => [...prev, key]);
+      setName("");
+    } catch (error) {
+      console.error("Error creating API key:", error);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await apiKeyService.remove(id);
+      setKeys((prev) => prev.filter((k) => k.id !== id));
+    } catch (error) {
+      console.error("Error deleting API key:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Key name"
+        />
+        <Button onClick={handleCreate}>Create</Button>
+      </div>
+
+      <ul className="space-y-2">
+        {keys.map((k) => (
+          <li
+            key={k.id}
+            className="flex items-center justify-between rounded border p-2"
+          >
+            <div>
+              <div className="font-medium">{k.name}</div>
+              <div className="break-all text-sm text-muted-foreground">
+                {k.key}
+              </div>
+            </div>
+            <Button
+              variant="destructive"
+              onClick={() => handleDelete(k.id)}
+            >
+              Delete
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/services/apiKeyService.ts
+++ b/frontend/src/services/apiKeyService.ts
@@ -1,0 +1,24 @@
+import { api } from "../lib/api";
+
+export interface ApiKey {
+  id: number;
+  name: string;
+  key: string;
+  createdAt: string;
+}
+
+export const apiKeyService = {
+  async list(): Promise<ApiKey[]> {
+    const { data } = await api.get<ApiKey[]>("/api-keys");
+    return data;
+  },
+
+  async create(name: string): Promise<ApiKey> {
+    const { data } = await api.post<ApiKey>("/api-keys", { name });
+    return data;
+  },
+
+  async remove(id: number): Promise<void> {
+    await api.delete(`/api-keys/${id}`);
+  },
+};


### PR DESCRIPTION
## Summary
- support API keys as alternative auth
- CRUD endpoints and UI for managing API keys
- add Prisma model and migration for API keys

## Testing
- `npm test` (fails: Password Protection Middleware and Redirection Service tests)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689aefed35ac832b8508f8ff8491fee1