### PR TITLE
fix: resolve flow MCP server path relative to module

### DIFF
--- a/backend/src/lib/configureFlowMcpServerEnv.cts
+++ b/backend/src/lib/configureFlowMcpServerEnv.cts
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+
+const SCRIPT_PATH_CANDIDATES = [
+  // Compiled output alongside dist/lib
+  path.resolve(__dirname, "../mcp/flowEditorServer.js"),
+  path.resolve(__dirname, "../mcp/flowEditorServer.ts"),
+  // Source tree fallback when running from backend root
+  path.resolve(__dirname, "../../mcp/flowEditorServer.js"),
+  path.resolve(__dirname, "../../mcp/flowEditorServer.ts"),
+];
+
+/**
+ * Resolve the Flow MCP server script path relative to this module.
+ * Prefers compiled JavaScript builds but gracefully falls back to
+ * the TypeScript source so development environments still work.
+ */
+export const resolveFlowMcpServerScript = (): string => {
+  for (const candidate of SCRIPT_PATH_CANDIDATES) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return SCRIPT_PATH_CANDIDATES[SCRIPT_PATH_CANDIDATES.length - 1];
+};
+
+/**
+ * Merge the Flow MCP server script path into the provided environment.
+ * Returning a cloned object avoids mutating the parent process env when
+ * spawning child processes.
+ */
+export const configureFlowMcpServerEnv = (
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv => {
+  const scriptPath = resolveFlowMcpServerScript();
+
+  return {
+    ...env,
+    FLOW_MCP_SERVER: scriptPath,
+    FLOW_MCP_SERVER_PATH: scriptPath,
+  };
+};

--- a/backend/src/start.js
+++ b/backend/src/start.js
@@ -2,6 +2,23 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
+let configureFlowMcpServerEnv = (env) => env;
+
+try {
+  ({ configureFlowMcpServerEnv } = require("./lib/configureFlowMcpServerEnv.cjs"));
+} catch (firstError) {
+  try {
+    ({ configureFlowMcpServerEnv } = require("./lib/configureFlowMcpServerEnv.js"));
+  } catch (secondError) {
+    if (process.env.NODE_ENV !== "test") {
+      console.warn(
+        "Flow MCP server environment helper unavailable, continuing with default environment.",
+        firstError.message || secondError.message
+      );
+    }
+  }
+}
+
 const DATA_DIR = process.env.ILA_DATA_DIR || path.join(process.cwd(), "data");
 const TMP_DIR = process.env.ILA_TMP_DATA_DIR || path.join(process.cwd(), "tmp");
 
@@ -29,9 +46,11 @@ async function startApp() {
     console.log(`IP location data directory: ${DATA_DIR}`);
     console.log(`IP location temp directory: ${TMP_DIR}`);
 
+    const childEnv = configureFlowMcpServerEnv(process.env);
+
     const app = spawn("node", [path.join(__dirname, "index.js")], {
       stdio: "inherit",
-      env: process.env,
+      env: childEnv,
     });
 
     app.on("close", (code) => {


### PR DESCRIPTION
## Summary
- add a Flow MCP server environment helper that resolves the script path relative to the current module and supports both source and built layouts
- update the backend start script to consume the helper when spawning the app and gracefully warn if the helper is unavailable

## Testing
- npm run build (fails: existing TypeScript errors in src/lib/bullmqSafeAdd.ts)


------
https://chatgpt.com/codex/tasks/task_e_68ebdbd2736c832b9f565b5b474d3d30