### PR TITLE
Ensure analytics respect selected project

### DIFF
--- a/frontend/src/contexts/project-context.tsx
+++ b/frontend/src/contexts/project-context.tsx
@@ -1,19 +1,27 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useMemo } from "react";
+
+import { useAuth } from "./AuthContext";
 
 interface ProjectContextType {
-  currentProjectId: number | undefined;
-  setCurrentProjectId: (id: number | undefined) => void;
+  currentProjectId: number | null;
+  setCurrentProjectId: (id: number | null) => void;
 }
 
 const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
 export function ProjectProvider({ children }: { children: React.ReactNode }) {
-  const [currentProjectId, setCurrentProjectId] = useState<number>();
+  const { currentProjectId, setCurrentProjectId } = useAuth();
+
+  const value = useMemo(
+    () => ({
+      currentProjectId,
+      setCurrentProjectId,
+    }),
+    [currentProjectId, setCurrentProjectId]
+  );
 
   return (
-    <ProjectContext.Provider value={{ currentProjectId, setCurrentProjectId }}>
-      {children}
-    </ProjectContext.Provider>
+    <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary
- share the project selection from the auth context through the project provider
- ensure analytics and other pages reference the same project id when loading data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fdfafb7694832b961728ab244afda2