### PR TITLE
feat(settings): allow editing profile information

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import {
   OtpSetupData,
-  User,
+  UpdateProfilePayload,
   changePassword as changePasswordApi,
   disableOTP as disableOTPApi,
   getBackupCodes as getBackupCodesApi,
@@ -11,7 +11,9 @@ import {
   removeDefaultProject,
   setDefaultProject,
   setupOTP as setupOTPApi,
+  updateProfile as updateProfileApi,
   verifyOTP as verifyOTPApi,
+  User,
 } from "@/lib/auth";
 import React, { createContext, useContext, useEffect, useState } from "react";
 
@@ -27,6 +29,7 @@ interface AuthContextType {
   signup: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  updateProfile: (data: UpdateProfilePayload) => Promise<void>;
   changePassword: (
     currentPassword: string,
     newPassword: string
@@ -133,6 +136,27 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       // Le toast est déjà géré dans la page RegisterPage
     } catch (error) {
       console.error("Signup error:", error);
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const updateProfile = async (
+    profileData: UpdateProfilePayload
+  ): Promise<void> => {
+    if (!user) {
+      throw new Error("User not authenticated");
+    }
+
+    try {
+      setIsLoading(true);
+      const updatedUser = await updateProfileApi(user.id, profileData);
+      setUser((prev) => (prev ? { ...prev, ...updatedUser } : prev));
+      toast.success("Profile updated successfully");
+    } catch (error) {
+      console.error("Profile update error:", error);
+      toast.error("Failed to update profile");
       throw error;
     } finally {
       setIsLoading(false);
@@ -247,6 +271,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     signup,
     logout,
     refreshUser,
+    updateProfile,
     changePassword,
     setupOTP,
     verifyOTP,

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -117,6 +117,36 @@ export interface OtpSetupData {
   backupCodes?: string[];
 }
 
+export type UpdateProfilePayload = Pick<
+  User,
+  "email" | "firstName" | "lastName"
+>;
+
+export type UpdateProfileResponse = Pick<
+  User,
+  "id" | "email" | "firstName" | "lastName" | "role"
+> & {
+  active?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export const updateProfile = async (
+  userId: number,
+  payload: UpdateProfilePayload
+): Promise<UpdateProfileResponse> => {
+  try {
+    const response = await api.put<UpdateProfileResponse>(
+      `/users/${userId}`,
+      payload
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Profile update error:", error);
+    throw error;
+  }
+};
+
 // Configurer l'OTP
 export const setupOTP = async (): Promise<OtpSetupData> => {
   try {

--- a/frontend/src/pages/settings/ProfileSettings.tsx
+++ b/frontend/src/pages/settings/ProfileSettings.tsx
@@ -5,16 +5,141 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const profileSchema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  email: z.string().email("Please enter a valid email address"),
+});
+
+type ProfileFormValues = z.infer<typeof profileSchema>;
 
 export default function ProfileSettings() {
+  const { user, updateProfile, isLoading } = useAuth();
+
+  const form = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      firstName: user?.firstName ?? "",
+      lastName: user?.lastName ?? "",
+      email: user?.email ?? "",
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      firstName: user?.firstName ?? "",
+      lastName: user?.lastName ?? "",
+      email: user?.email ?? "",
+    });
+  }, [user, form]);
+
+  const onSubmit = async (values: ProfileFormValues) => {
+    try {
+      await updateProfile(values);
+    } catch {
+      // Errors are handled by the auth context toasts
+    }
+  };
+
+  const isSubmitting = form.formState.isSubmitting || isLoading;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>User Profile</CardTitle>
-        <CardDescription>Manage your profile information</CardDescription>
+        <CardDescription>
+          Update your personal information so teammates can recognize you.
+        </CardDescription>
       </CardHeader>
-      <CardContent>
-        <p>Profile options will be displayed here.</p>
+      <CardContent className="space-y-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid gap-6 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First name</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Jane"
+                        disabled={isSubmitting}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last name</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Doe"
+                        disabled={isSubmitting}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email address</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="name@example.com"
+                      disabled={isSubmitting}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end">
+              <Button type="submit" disabled={isSubmitting || !user}>
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving
+                  </>
+                ) : (
+                  "Save changes"
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add API helper and context wiring to update the signed-in user's profile
- implement the profile settings form so name and email can be edited with validation and loading feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fdfacba368832b9b5387d9103e83e9