### PR TITLE
Add project membership support to backend

### DIFF
--- a/backend/prisma/migrations/20251101120000_add_project_memberships/migration.sql
+++ b/backend/prisma/migrations/20251101120000_add_project_memberships/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE `ProjectMember` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `projectId` INTEGER NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `role` ENUM('MEMBER', 'ADMIN') NOT NULL DEFAULT 'MEMBER',
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `ProjectMember_userId_idx`(`userId`),
+    UNIQUE INDEX `ProjectMember_projectId_userId_key`(`projectId`, `userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `ProjectMember` ADD CONSTRAINT `ProjectMember_projectId_fkey` FOREIGN KEY (`projectId`) REFERENCES `Project`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ProjectMember` ADD CONSTRAINT `ProjectMember_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,37 +11,57 @@ datasource db {
 }
 
 model User {
-    id             Int       @id @default(autoincrement())
-    email          String    @unique
-    firstName      String?
-    lastName       String?
-    password       String
-    role           Role      @default(USER)
-    active         Boolean   @default(true)
-    otpEnabled     Boolean   @default(false) // Indique si l'OTP est activé
-    otpSecret      String? // Clé secrète pour l'OTP (nullable car optionnel)
-    otpVerified    Boolean   @default(false) // Indique si l'OTP a été vérifié
-    otpBackupCodes String? // Pour stocker les codes de secours (JSON formaté)
-    seenTips       String? // Store seen tips IDs as JSON array
-    theme          String?   @default("system") // Added theme preference
-    lastProjectId  Int? // Added to store the last selected project
-    projects       Project[]
-    apiKeys        ApiKey[]
-    createdAt      DateTime  @default(now())
-    updatedAt      DateTime  @updatedAt
+    id                 Int             @id @default(autoincrement())
+    email              String          @unique
+    firstName          String?
+    lastName           String?
+    password           String
+    role               Role            @default(USER)
+    active             Boolean         @default(true)
+    otpEnabled         Boolean         @default(false) // Indique si l'OTP est activé
+    otpSecret          String? // Clé secrète pour l'OTP (nullable car optionnel)
+    otpVerified        Boolean         @default(false) // Indique si l'OTP a été vérifié
+    otpBackupCodes     String? // Pour stocker les codes de secours (JSON formaté)
+    seenTips           String? // Store seen tips IDs as JSON array
+    theme              String?         @default("system") // Added theme preference
+    lastProjectId      Int? // Added to store the last selected project
+    projects           Project[]       @relation("OwnedProjects")
+    projectMemberships ProjectMember[]
+    apiKeys            ApiKey[]
+    createdAt          DateTime        @default(now())
+    updatedAt          DateTime        @updatedAt
 }
 
 model Project {
-    id          Int      @id @default(autoincrement())
+    id          Int             @id @default(autoincrement())
     name        String
     description String?
-    user        User     @relation(fields: [userId], references: [id])
+    user        User            @relation("OwnedProjects", fields: [userId], references: [id])
     userId      Int
+    members     ProjectMember[]
     links       Link[]
-    createdAt   DateTime @default(now())
-    updatedAt   DateTime @updatedAt
+    createdAt   DateTime        @default(now())
+    updatedAt   DateTime        @updatedAt
 
     @@index([userId])
+}
+
+model ProjectMember {
+    id        Int               @id @default(autoincrement())
+    project   Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
+    projectId Int
+    user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId    Int
+    role      ProjectMemberRole @default(MEMBER)
+    createdAt DateTime          @default(now())
+
+    @@unique([projectId, userId])
+    @@index([userId])
+}
+
+enum ProjectMemberRole {
+    MEMBER
+    ADMIN
 }
 
 model Link {

--- a/backend/src/controllers/project.ts
+++ b/backend/src/controllers/project.ts
@@ -1,6 +1,9 @@
+import { ProjectMemberRole } from "@prisma/client";
 import { Request, Response } from "express";
 
 import prisma from "../lib/prisma";
+import { getProjectMemberInvitationTemplate } from "../templates/project-member-invite";
+import { sendEmail } from "../utils/email";
 
 const ALLOWED_SORT_FIELDS = [
   "id",
@@ -19,10 +22,43 @@ export const getProjects = async (req: Request, res: Response) => {
     const isAdmin = req.user?.role === "ADMIN";
 
     const projects = await prisma.project.findMany({
-      where: isAdmin ? {} : { userId },
+      where: isAdmin
+        ? {}
+        : {
+            OR: [
+              { userId },
+              {
+                members: {
+                  some: {
+                    userId,
+                  },
+                },
+              },
+            ],
+          },
+      include: {
+        members: {
+          where: { userId },
+          select: { role: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
     });
 
-    res.json({ data: projects });
+    const formattedProjects = projects.map((project) => ({
+      id: project.id,
+      name: project.name,
+      description: project.description,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+      role: isAdmin
+        ? "ADMIN"
+        : project.userId === userId
+        ? "OWNER"
+        : project.members[0]?.role ?? ProjectMemberRole.MEMBER,
+    }));
+
+    res.json({ data: formattedProjects });
   } catch (error) {
     res.status(500).json({ message: "Error fetching projects" });
   }
@@ -30,16 +66,36 @@ export const getProjects = async (req: Request, res: Response) => {
 
 export const getProjectById = async (req: Request, res: Response) => {
   try {
-    const { id } = req.params;
+    const projectId = req.validatedProjectId ?? parseInt(req.params.id);
     const project = await prisma.project.findUnique({
-      where: { id: parseInt(id) },
+      where: { id: projectId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
     });
 
     if (!project) {
       return res.status(404).json({ message: "Project not found" });
     }
 
-    res.json({ data: project });
+    res.json({
+      data: {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt,
+        owner: project.user,
+        role: req.projectAccess?.role ?? (req.user?.role === "ADMIN" ? "ADMIN" : "MEMBER"),
+      },
+    });
   } catch (error) {
     res.status(500).json({ message: "Error fetching project" });
   }
@@ -122,6 +178,9 @@ export const createProject = async (req: Request, res: Response) => {
 
 export const updateProject = async (req: Request, res: Response) => {
   try {
+    if (!req.projectAccess?.isOwner && !req.projectAccess?.isAdmin) {
+      return res.status(403).json({ message: "Only project owners can update" });
+    }
     const { id } = req.params;
     const { name, description } = req.body;
 
@@ -138,6 +197,9 @@ export const updateProject = async (req: Request, res: Response) => {
 
 export const deleteProject = async (req: Request, res: Response) => {
   try {
+    if (!req.projectAccess?.isOwner && !req.projectAccess?.isAdmin) {
+      return res.status(403).json({ message: "Only project owners can delete" });
+    }
     const { id } = req.params;
 
     await prisma.project.delete({
@@ -147,5 +209,209 @@ export const deleteProject = async (req: Request, res: Response) => {
     res.status(204).send();
   } catch (error) {
     res.status(500).json({ message: "Error deleting project" });
+  }
+};
+
+export const getProjectMembers = async (req: Request, res: Response) => {
+  try {
+    const projectId = req.validatedProjectId ?? parseInt(req.params.id, 10);
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        members: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    if (!project) {
+      return res.status(404).json({ message: "Project not found" });
+    }
+
+    const response = {
+      owner: {
+        id: project.user.id,
+        email: project.user.email,
+        firstName: project.user.firstName,
+        lastName: project.user.lastName,
+      },
+      members: project.members.map((member) => ({
+        id: member.id,
+        role: member.role,
+        createdAt: member.createdAt,
+        user: {
+          id: member.user.id,
+          email: member.user.email,
+          firstName: member.user.firstName,
+          lastName: member.user.lastName,
+        },
+      })),
+    };
+
+    res.json({ data: response });
+  } catch (error) {
+    console.error("Error fetching project members", error);
+    res.status(500).json({ message: "Error fetching project members" });
+  }
+};
+
+export const addProjectMember = async (req: Request, res: Response) => {
+  try {
+    if (!req.projectAccess?.isOwner && !req.projectAccess?.isAdmin) {
+      return res.status(403).json({ message: "Only project owners can invite members" });
+    }
+
+    const projectId = req.validatedProjectId ?? parseInt(req.params.id, 10);
+    const { email, role = ProjectMemberRole.MEMBER } = req.body as {
+      email?: string;
+      role?: ProjectMemberRole;
+    };
+
+    if (!email) {
+      return res.status(400).json({ message: "Member email is required" });
+    }
+
+    const userToInvite = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!userToInvite) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    if (userToInvite.id === req.user?.id) {
+      return res
+        .status(400)
+        .json({ message: "Owners do not need to invite themselves" });
+    }
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      include: { user: true },
+    });
+
+    if (!project) {
+      return res.status(404).json({ message: "Project not found" });
+    }
+
+    if (project.userId === userToInvite.id) {
+      return res
+        .status(400)
+        .json({ message: "The project owner already has access" });
+    }
+
+    const normalizedRole =
+      role === ProjectMemberRole.ADMIN
+        ? ProjectMemberRole.ADMIN
+        : ProjectMemberRole.MEMBER;
+
+    const existingMember = await prisma.projectMember.findUnique({
+      where: {
+        projectId_userId: {
+          projectId,
+          userId: userToInvite.id,
+        },
+      },
+    });
+
+    if (existingMember) {
+      return res
+        .status(409)
+        .json({ message: "User is already a project member" });
+    }
+
+    const newMember = await prisma.projectMember.create({
+      data: {
+        project: { connect: { id: projectId } },
+        user: { connect: { id: userToInvite.id } },
+        role: normalizedRole,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    });
+
+    try {
+      await sendEmail({
+        to: userToInvite.email,
+        subject: `You've been invited to ${project.name}`,
+        html: getProjectMemberInvitationTemplate({
+          projectName: project.name,
+          inviterEmail: req.user?.email ?? "",
+        }),
+      });
+    } catch (emailError) {
+      console.error("Error sending project invitation email", emailError);
+    }
+
+    res.status(201).json({
+      data: {
+        id: newMember.id,
+        role: newMember.role,
+        createdAt: newMember.createdAt,
+        user: newMember.user,
+      },
+    });
+  } catch (error) {
+    console.error("Error adding project member", error);
+    res.status(500).json({ message: "Error adding project member" });
+  }
+};
+
+export const removeProjectMember = async (req: Request, res: Response) => {
+  try {
+    const projectId = req.validatedProjectId ?? parseInt(req.params.id, 10);
+    const memberId = parseInt(req.params.memberId, 10);
+
+    const membership = await prisma.projectMember.findUnique({
+      where: { id: memberId },
+    });
+
+    if (!membership || membership.projectId !== projectId) {
+      return res.status(404).json({ message: "Project member not found" });
+    }
+
+    const isSelfRemoval = membership.userId === req.user?.id;
+
+    if (!req.projectAccess?.isAdmin && !req.projectAccess?.isOwner && !isSelfRemoval) {
+      return res
+        .status(403)
+        .json({ message: "Not authorized to remove this member" });
+    }
+
+    await prisma.projectMember.delete({
+      where: { id: memberId },
+    });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("Error removing project member", error);
+    res.status(500).json({ message: "Error removing project member" });
   }
 };

--- a/backend/src/middleware/projectAccess.ts
+++ b/backend/src/middleware/projectAccess.ts
@@ -10,11 +10,17 @@ export const validateProjectAccess = async (
     const userId = req.user?.id;
     const role = req.user?.role;
     const isAdmin = role === "ADMIN";
-    const projectId =
+    const projectIdentifier =
       req.currentProjectId ||
       req.params.projectId ||
+      req.params.id ||
       req.query.projectId ||
+      req.headers["x-project-id"] ||
       req.headers["X-Project-ID"];
+
+    const projectId = projectIdentifier
+      ? parseInt(projectIdentifier as string, 10)
+      : undefined;
 
     if (!projectId) {
       return next();
@@ -24,10 +30,15 @@ export const validateProjectAccess = async (
       return res.status(401).json({ message: "Authentication required" });
     }
 
-    const project = await prisma.project.findFirst({
+    const project = await prisma.project.findUnique({
       where: {
-        id: parseInt(projectId as string),
-        ...(isAdmin ? {} : { userId: userId }),
+        id: projectId,
+      },
+      include: {
+        members: {
+          where: { userId },
+          select: { id: true, role: true, userId: true },
+        },
       },
     });
 
@@ -37,8 +48,23 @@ export const validateProjectAccess = async (
         .json({ message: "Project not found or access denied" });
     }
 
+    const isOwner = project.userId === userId;
+    const membership = project.members[0];
+
+    if (!isAdmin && !isOwner && !membership) {
+      return res
+        .status(403)
+        .json({ message: "Project not found or access denied" });
+    }
+
     // Add validated project to request
     req.validatedProjectId = project.id;
+    req.projectAccess = {
+      role: isAdmin ? "ADMIN" : isOwner ? "OWNER" : membership?.role ?? "MEMBER",
+      isOwner,
+      isAdmin,
+      membershipId: membership?.id,
+    };
     next();
   } catch (error) {
     console.error("Project access validation error:", error);

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -1,6 +1,6 @@
 import * as projectController from "../controllers/project";
 
-import { authenticateJWT, isAdmin } from "../middleware/auth";
+import { authenticateJWT } from "../middleware/auth";
 
 import { Router } from "express";
 import { validateProjectAccess } from "../middleware/projectAccess";
@@ -10,14 +10,29 @@ const router = Router();
 // All routes require authentication
 router.use(authenticateJWT);
 
-// Admin routes
-router.get("/", isAdmin, projectController.getProjects);
+router.get("/", projectController.getProjects);
 
 // Non-admin routes with project access validation
 router.get("/:id", validateProjectAccess, projectController.getProjectById);
 router.post("/", projectController.createProject);
 router.put("/:id", validateProjectAccess, projectController.updateProject);
 router.delete("/:id", validateProjectAccess, projectController.deleteProject);
+
+router.get(
+  "/:id/members",
+  validateProjectAccess,
+  projectController.getProjectMembers
+);
+router.post(
+  "/:id/members",
+  validateProjectAccess,
+  projectController.addProjectMember
+);
+router.delete(
+  "/:id/members/:memberId",
+  validateProjectAccess,
+  projectController.removeProjectMember
+);
 
 // Project specific analytics
 router.get(

--- a/backend/src/templates/project-member-invite.ts
+++ b/backend/src/templates/project-member-invite.ts
@@ -1,0 +1,21 @@
+interface ProjectMemberInvitationPayload {
+  projectName: string;
+  inviterEmail: string;
+}
+
+export const getProjectMemberInvitationTemplate = (
+  payload: ProjectMemberInvitationPayload
+) => `
+  <div style="font-family: Arial, sans-serif; color: #1f2933; padding: 24px;">
+    <h2 style="margin-bottom: 16px;">You've been invited to join ${payload.projectName}</h2>
+    <p style="margin-bottom: 16px;">
+      ${payload.inviterEmail} has added you as a member of the <strong>${payload.projectName}</strong> project.
+    </p>
+    <p style="margin-bottom: 16px;">
+      Sign in to your referral tool account to collaborate with the rest of the team.
+    </p>
+    <p style="margin-bottom: 0; color: #52606d; font-size: 14px;">
+      If you believe this invitation was sent in error, you can safely ignore this message.
+    </p>
+  </div>
+`;

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -2,5 +2,11 @@ declare namespace Express {
   interface Request {
     currentProjectId?: string;
     validatedProjectId?: number;
+    projectAccess?: {
+      role: "OWNER" | "MEMBER" | "ADMIN";
+      isOwner: boolean;
+      isAdmin: boolean;
+      membershipId?: number;
+    };
   }
 }

--- a/backend/tests/controllers/project.test.ts
+++ b/backend/tests/controllers/project.test.ts
@@ -1,0 +1,223 @@
+import { ProjectMemberRole, PrismaClient } from "@prisma/client";
+import type { Request, Response } from "express";
+import { DeepMockProxy } from "jest-mock-extended";
+
+import {
+  addProjectMember,
+  getProjectMembers,
+  getProjects,
+  removeProjectMember,
+} from "../../src/controllers/project";
+import prisma from "../../src/lib/prisma";
+import { sendEmail } from "../../src/utils/email";
+
+type MockResponse = Partial<Response> & {
+  status: jest.MockedFunction<Response["status"]>;
+  json: jest.MockedFunction<Response["json"]>;
+  send?: jest.MockedFunction<Response["send"]>;
+};
+
+jest.mock("../../src/utils/email", () => ({
+  sendEmail: jest.fn().mockResolvedValue(true),
+}));
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+
+const createMockResponse = (): MockResponse => {
+  const res: MockResponse = {
+    status: jest.fn().mockReturnThis() as unknown as Response["status"],
+    json: jest.fn(),
+    send: jest.fn(),
+  };
+  return res;
+};
+
+describe("project controller", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.project.findMany.mockReset();
+    prismaMock.user.findUnique.mockReset();
+    prismaMock.projectMember.findUnique.mockReset();
+    prismaMock.projectMember.create.mockReset();
+    prismaMock.project.findUnique.mockReset();
+    prismaMock.projectMember.delete.mockReset();
+  });
+
+  describe("getProjects", () => {
+    it("returns projects owned by or shared with the user", async () => {
+      const req = {
+        user: { id: 1, role: "USER" },
+      } as unknown as Request;
+      const res = createMockResponse();
+
+      prismaMock.project.findMany.mockResolvedValue([
+        {
+          id: 10,
+          name: "Owner Project",
+          description: null,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-02"),
+          userId: 1,
+          members: [],
+        } as any,
+        {
+          id: 20,
+          name: "Shared Project",
+          description: null,
+          createdAt: new Date("2024-02-01"),
+          updatedAt: new Date("2024-02-02"),
+          userId: 2,
+          members: [{ role: ProjectMemberRole.MEMBER }],
+        } as any,
+      ]);
+
+      await getProjects(req, res as Response);
+
+      expect(prismaMock.project.findMany).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.arrayContaining([
+            expect.objectContaining({ id: 10, role: "OWNER" }),
+            expect.objectContaining({ id: 20, role: ProjectMemberRole.MEMBER }),
+          ]),
+        })
+      );
+    });
+  });
+
+  describe("addProjectMember", () => {
+    it("creates a project membership and sends an email", async () => {
+      const req = {
+        user: { id: 1, email: "owner@example.com", role: "USER" },
+        projectAccess: { isOwner: true, isAdmin: false, role: "OWNER" },
+        params: { id: "10" },
+        body: { email: "member@example.com", role: ProjectMemberRole.ADMIN },
+        validatedProjectId: 10,
+      } as unknown as Request;
+      const res = createMockResponse();
+
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: 2,
+        email: "member@example.com",
+      } as any);
+      prismaMock.project.findUnique.mockResolvedValue({
+        id: 10,
+        name: "Project 10",
+        userId: 1,
+        user: { id: 1, email: "owner@example.com" },
+      } as any);
+      prismaMock.projectMember.findUnique.mockResolvedValue(null);
+      const createdMember = {
+        id: 55,
+        projectId: 10,
+        userId: 2,
+        role: ProjectMemberRole.ADMIN,
+        createdAt: new Date("2024-03-01"),
+        user: {
+          id: 2,
+          email: "member@example.com",
+          firstName: "Member",
+          lastName: "Example",
+        },
+      } as any;
+      prismaMock.projectMember.create.mockResolvedValue(createdMember);
+
+      await addProjectMember(req, res as Response);
+
+      expect(prismaMock.projectMember.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            project: { connect: { id: 10 } },
+            user: { connect: { id: 2 } },
+            role: ProjectMemberRole.ADMIN,
+          }),
+        })
+      );
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "member@example.com",
+          subject: expect.stringContaining("Project 10"),
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ id: 55, role: ProjectMemberRole.ADMIN }),
+        })
+      );
+    });
+  });
+
+  describe("getProjectMembers", () => {
+    it("returns owner info and member list", async () => {
+      const req = {
+        params: { id: "10" },
+        validatedProjectId: 10,
+      } as unknown as Request;
+      const res = createMockResponse();
+
+      prismaMock.project.findUnique.mockResolvedValue({
+        id: 10,
+        name: "Project 10",
+        user: {
+          id: 1,
+          email: "owner@example.com",
+          firstName: "Owner",
+          lastName: "User",
+        },
+        members: [
+          {
+            id: 100,
+            role: ProjectMemberRole.MEMBER,
+            createdAt: new Date("2024-04-01"),
+            user: {
+              id: 2,
+              email: "member@example.com",
+              firstName: "Member",
+              lastName: "User",
+            },
+          },
+        ],
+      } as any);
+
+      await getProjectMembers(req, res as Response);
+
+      expect(prismaMock.project.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 10 } })
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            owner: expect.objectContaining({ email: "owner@example.com" }),
+            members: expect.arrayContaining([
+              expect.objectContaining({ role: ProjectMemberRole.MEMBER }),
+            ]),
+          },
+        })
+      );
+    });
+  });
+
+  describe("removeProjectMember", () => {
+    it("prevents removing another member without permissions", async () => {
+      const req = {
+        params: { id: "10", memberId: "200" },
+        validatedProjectId: 10,
+        user: { id: 3, role: "USER" },
+        projectAccess: { isOwner: false, isAdmin: false, role: "MEMBER" },
+      } as unknown as Request;
+      const res = createMockResponse();
+
+      prismaMock.projectMember.findUnique.mockResolvedValue({
+        id: 200,
+        projectId: 10,
+        userId: 2,
+      } as any);
+
+      await removeProjectMember(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(prismaMock.projectMember.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/middleware/projectAccess.test.ts
+++ b/backend/tests/middleware/projectAccess.test.ts
@@ -1,0 +1,86 @@
+import { PrismaClient } from "@prisma/client";
+import type { Request, Response, NextFunction } from "express";
+import { DeepMockProxy } from "jest-mock-extended";
+
+import prisma from "../../src/lib/prisma";
+import { validateProjectAccess } from "../../src/middleware/projectAccess";
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+
+describe("validateProjectAccess", () => {
+  let next: jest.MockedFunction<NextFunction>;
+  let res: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.project.findUnique.mockReset();
+    next = jest.fn();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Response;
+  });
+
+  it("allows access when user owns the project", async () => {
+    const req = {
+      params: { id: "10" },
+      user: { id: 1, role: "USER" },
+    } as unknown as Request;
+
+    prismaMock.project.findUnique.mockResolvedValue({
+      id: 10,
+      userId: 1,
+      members: [],
+    });
+
+    await validateProjectAccess(req, res, next);
+
+    expect(req.validatedProjectId).toBe(10);
+    expect(req.projectAccess).toEqual(
+      expect.objectContaining({ role: "OWNER", isOwner: true })
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("allows access when user is a project member", async () => {
+    const req = {
+      params: { id: "20" },
+      user: { id: 5, role: "USER" },
+    } as unknown as Request;
+
+    prismaMock.project.findUnique.mockResolvedValue({
+      id: 20,
+      userId: 2,
+      members: [{ id: 99, userId: 5, role: "MEMBER" }],
+    });
+
+    await validateProjectAccess(req, res, next);
+
+    expect(req.validatedProjectId).toBe(20);
+    expect(req.projectAccess).toEqual(
+      expect.objectContaining({ role: "MEMBER", membershipId: 99 })
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 when user lacks access", async () => {
+    const req = {
+      params: { id: "30" },
+      user: { id: 3, role: "USER" },
+    } as unknown as Request;
+
+    prismaMock.project.findUnique.mockResolvedValue({
+      id: 30,
+      userId: 1,
+      members: [],
+    });
+
+    await validateProjectAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    expect(req.validatedProjectId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce ProjectMember model and migration to link users to projects with roles
- update project access middleware, controllers, and routes to honour members alongside owners and to manage invitations
- add email template and Jest coverage for project membership flows

## Testing
- `npm test -- --runInBand tests/controllers/project.test.ts tests/middleware/projectAccess.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68fdfb57f5ac832bbc62d4cb2cb16663