### PR TITLE
Add CTA button to project invite email

### DIFF
--- a/backend/src/templates/project-member-invite.ts
+++ b/backend/src/templates/project-member-invite.ts
@@ -17,5 +17,21 @@ export const getProjectMemberInvitationTemplate = (
     <p style="margin-bottom: 0; color: #52606d; font-size: 14px;">
       If you believe this invitation was sent in error, you can safely ignore this message.
     </p>
+    <div style="margin-top: 24px;">
+      <a
+        href="https://rflnk.com"
+        style="
+          display: inline-block;
+          padding: 12px 24px;
+          background-color: #0b69a3;
+          color: #ffffff;
+          text-decoration: none;
+          border-radius: 6px;
+          font-weight: 600;
+        "
+      >
+        Go to rflnk.com
+      </a>
+    </div>
   </div>
 `;


### PR DESCRIPTION
## Summary
- add a call-to-action button linking to rflnk.com at the end of the project member invitation email template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe04ab697c832b9aa6809200daf760