### PR TITLE
Handle ip-location-api long postcode overflow

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,6 +55,7 @@
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.7",
         "nodemon": "^3.0.1",
+        "patch-package": "^8.0.1",
         "prisma": "^6.17.0",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.2",
@@ -2019,6 +2020,13 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2662,6 +2670,25 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3368,6 +3395,24 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -4122,6 +4167,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -4195,6 +4250,21 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs-minipass": {
@@ -4422,6 +4492,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4852,6 +4935,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4948,6 +5047,26 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5855,6 +5974,26 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5865,6 +6004,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -5918,6 +6080,16 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -6950,6 +7122,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -6994,6 +7176,23 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7155,6 +7354,46 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -7823,6 +8062,24 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8298,6 +8555,16 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
       "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA=="
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8618,6 +8885,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -8961,6 +9238,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "prisma:migrate": "prisma migrate dev --name",
     "prisma:studio": "prisma studio",
     "prisma:reset": "prisma migrate reset --force",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "postinstall": "patch-package"
   },
   "keywords": [
     "node",
@@ -69,6 +70,7 @@
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.7",
     "nodemon": "^3.0.1",
+    "patch-package": "^8.0.1",
     "prisma": "^6.17.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",

--- a/backend/patches/ip-location-api+2.4.3.patch
+++ b/backend/patches/ip-location-api+2.4.3.patch
@@ -1,0 +1,520 @@
+diff --git a/node_modules/ip-location-api/src/db.mjs b/node_modules/ip-location-api/src/db.mjs
+index de1c376..0adf54f 100644
+--- a/node_modules/ip-location-api/src/db.mjs
++++ b/node_modules/ip-location-api/src/db.mjs
+@@ -11,11 +11,30 @@ import { Address4, Address6 } from 'ip-address'
+ import dayjs from 'dayjs'
+ 
+ import { setting, consoleLog, consoleWarn } from './setting.mjs'
+-import { getPostcodeDatabase, strToNum37, aton4, aton6, getSmallMemoryFile, numberToDir, countryCodeToNum } from './utils.mjs'
++import { LONG_POSTCODE_MARKER, getPostcodeDatabase, strToNum37, aton4, aton6, getSmallMemoryFile, numberToDir, countryCodeToNum } from './utils.mjs'
+ 
+ const __filename = fileURLToPath(import.meta.url)
+ const __dirname = path.dirname(__filename)
+ 
++const MAX_UINT32 = 0xFFFFFFFF
++const longPostcodeList = ['']
++const longPostcodeIndex = new Map()
++const getPostcodeForStorage = (postcode) => {
++        if(!postcode) return [0, 0]
++        const normalized = postcode.toUpperCase()
++        const result = getPostcodeDatabase(normalized)
++        if(result[1] <= MAX_UINT32) {
++                return result
++        }
++        var index = longPostcodeIndex.get(normalized)
++        if(!index){
++                index = longPostcodeList.length
++                longPostcodeIndex.set(normalized, index)
++                longPostcodeList.push(normalized)
++        }
++        return [LONG_POSTCODE_MARKER, index]
++}
++
+ const rimraf = (dir) => {
+ 	if(fs.rm){
+ 		return fs.rm(dir, {recursive: true, force: true, maxRetries: 3})
+@@ -377,7 +396,10 @@ const sha256Hash = async (file) => {
+ }
+ 
+ const createData = async (src) => {
+-	var mapDatas = []
++        longPostcodeIndex.clear()
++        longPostcodeList.length = 1
++        longPostcodeList[0] = ''
++        var mapDatas = []
+ 	var locationSrc = src.filter(file => file.includes('Locations'))
+ 	locationSrc.sort((a,b) => {
+ 		// Locations-en.csv should be the first
+@@ -392,12 +414,15 @@ const createData = async (src) => {
+ 	}
+ 	var blockSrc = src.filter(file => file.includes('Blocks'))
+ 	mapDatas.push([])
+-	for(var file of blockSrc){
+-		await createMainData(file, mapDatas)
+-	}
+-	if(setting.locFile){
+-		await createMapData(mapDatas)
+-	}
++        for(var file of blockSrc){
++                await createMainData(file, mapDatas)
++        }
++        if(setting.locFile){
++                await createMapData(mapDatas)
++        } else {
++                const payload = longPostcodeList.length > 1 ? { longPostcode: longPostcodeList.slice() } : {}
++                await fs.writeFile(path.join(setting.fieldDir, 'sub.json.tmp'), JSON.stringify(payload))
++        }
+ }
+ 
+ 
+@@ -598,12 +623,12 @@ const createMainData = async (file, mapDatas) => {
+ 							buffer3.writeInt32LE(longitude, offset)
+ 							offset += 4
+ 						}
+-						if(setting.mainFieldHash.postcode) {
+-							var postcodeDb = getPostcodeDatabase(postcode)
+-							buffer3.writeUInt32LE(postcodeDb[1], offset)
+-							buffer3.writeInt8(postcodeDb[0], offset + 4)
+-							offset += 5
+-						}
++                                                if(setting.mainFieldHash.postcode) {
++                                                        var postcodeDb = getPostcodeForStorage(postcode)
++                                                        buffer3.writeUInt32LE(postcodeDb[1], offset)
++                                                        buffer3.writeInt8(postcodeDb[0], offset + 4)
++                                                        offset += 5
++                                                }
+ 						if(setting.mainFieldHash.area) {
+ 							buffer3.writeUInt8(makeAreaDatabase(area), offset)
+ 						}
+@@ -780,21 +805,22 @@ const createMapData = async (mapDatas) => {
+ 	ws1.end()
+ 	ws2.end()
+ 
+-	var hash = {
+-		region1_name: DatabaseToArray(sub1Database),
+-		region2_name: DatabaseToArray(sub2Database),
+-		timezone: DatabaseToArray(timezoneDatabase),
+-		area: DatabaseToArray(areaDatabase).map(v => parseInt(v, 10)||0),
+-		eu: euHash
+-	}
++        var hash = {
++                region1_name: DatabaseToArray(sub1Database),
++                region2_name: DatabaseToArray(sub2Database),
++                timezone: DatabaseToArray(timezoneDatabase),
++                area: DatabaseToArray(areaDatabase).map(v => parseInt(v, 10)||0),
++                eu: euHash
++        }
++        if(longPostcodeList.length > 1){
++                hash.longPostcode = longPostcodeList.slice()
++        }
+ 	if(!setting.locFieldHash.region1_name) delete hash.region1_name
+ 	if(!setting.locFieldHash.region2_name) delete hash.region2_name
+ 	if(!setting.locFieldHash.timezone) delete hash.timezone
+ 	if(!setting.mainFieldHash.area) delete hash.area
+ 	if(!setting.locFieldHash.eu) delete hash.eu
+-	if(Object.keys(hash).length > 0){
+-		await fs.writeFile(path.join(setting.fieldDir, 'sub.json.tmp'), JSON.stringify(hash))
+-	}
++        await fs.writeFile(path.join(setting.fieldDir, 'sub.json.tmp'), JSON.stringify(hash))
+ 	sub1Database = sub2Database = timezoneDatabase = areaDatabase = null
+ 	mapDatas.length = 0
+ }
+diff --git a/node_modules/ip-location-api/src/main-pack.mjs b/node_modules/ip-location-api/src/main-pack.mjs
+index 0850e36..efd66f9 100644
+--- a/node_modules/ip-location-api/src/main-pack.mjs
++++ b/node_modules/ip-location-api/src/main-pack.mjs
+@@ -8,7 +8,7 @@ import { countries, continents } from 'countries-list'
+ import { CronJob } from 'cron'
+ 
+ import { setting, setSetting, getSettingCmd, consoleLog, consoleWarn } from './setting.mjs'
+-import { num37ToStr, getSmallMemoryFile, getZeroFill, aton6Start, aton4 } from './utils.mjs'
++import { LONG_POSTCODE_MARKER, num37ToStr, getSmallMemoryFile, getZeroFill, aton6Start, aton4 } from './utils.mjs'
+ import { update as updataDbAsync } from './db.mjs'
+ 
+ const v4db = setting.v4
+@@ -193,10 +193,10 @@ export const setupWithoutReload = setSetting
+  */
+ export const clear = () => {
+ 	v4db.startIps = v6db.startIps = v4db.endIps = v6db.endIps = v4db.mainBuffer = v6db.mainBuffer = null
+-	Region1NameJson = Region2NameJson = TimezoneJson = LocBuffer = CityNameBuffer = EuJson = null
++Region1NameJson = Region2NameJson = TimezoneJson = LocBuffer = CityNameBuffer = EuJson = LongPostcodeJson = null
+ }
+ 
+-var Region1NameJson, Region2NameJson, TimezoneJson, LocBuffer, CityNameBuffer, AreaJson, EuJson
++var Region1NameJson, Region2NameJson, TimezoneJson, LocBuffer, CityNameBuffer, AreaJson, EuJson, LongPostcodeJson
+ var updateJob
+ /**
+  * reload in-memory database
+@@ -228,7 +228,10 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 		citySub: 		  path.join(dataDir, 'sub.json')
+ 	}
+ 
+-	var locBuffer, cityNameBuffer, subBuffer
++        const needSubFile = locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu || mainFieldHash.postcode
++        const hasSubFile = needSubFile && fsSync.existsSync(dataFiles.citySub)
++
++        var locBuffer, cityNameBuffer, subBuffer
+ 	var buffer41, buffer42, buffer43, buffer61, buffer62, buffer63
+ 	if(sync){
+ 		if(!fsSync.existsSync(dataFiles.v41)){
+@@ -244,15 +247,17 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 			buffer62 = fsSync.readFileSync(dataFiles.v62)
+ 			buffer63 = fsSync.readFileSync(dataFiles.v63)
+ 		}
+-		if(curSetting.locFile){
+-			locBuffer = fsSync.readFileSync(dataFiles.cityLocation)
+-			if(locFieldHash.city){
+-				cityNameBuffer = fsSync.readFileSync(dataFiles.cityName)
+-			}
+-			if(locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu){
+-				subBuffer = fsSync.readFileSync(dataFiles.citySub)
+-			}
+-		}
++                if(curSetting.locFile){
++                        locBuffer = fsSync.readFileSync(dataFiles.cityLocation)
++                        if(locFieldHash.city){
++                                cityNameBuffer = fsSync.readFileSync(dataFiles.cityName)
++                        }
++                }
++                if(hasSubFile){
++                        subBuffer = fsSync.readFileSync(dataFiles.citySub)
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
+ 	} else {
+ 		if(!fsSync.existsSync(dataFiles.v41)){
+ 			consoleLog('Database creating ...')
+@@ -271,16 +276,18 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 				fs.readFile(dataFiles.v63).then(data => buffer63 = data)
+ 			)
+ 		}
+-		if(curSetting.locFile){
+-			prs.push(fs.readFile(dataFiles.cityLocation).then(data => locBuffer = data))
+-			if(locFieldHash.city){
+-				prs.push(fs.readFile(dataFiles.cityName).then(data => cityNameBuffer = data))
+-			}
+-			if(locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu){
+-				prs.push(fs.readFile(dataFiles.citySub).then(data => subBuffer = data))
+-			}
+-		}
+-		await Promise.all(prs)
++                if(curSetting.locFile){
++                        prs.push(fs.readFile(dataFiles.cityLocation).then(data => locBuffer = data))
++                        if(locFieldHash.city){
++                                prs.push(fs.readFile(dataFiles.cityName).then(data => cityNameBuffer = data))
++                        }
++                }
++                if(hasSubFile){
++                        prs.push(fs.readFile(dataFiles.citySub).then(data => subBuffer = data))
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
++                await Promise.all(prs)
+ 	}
+ 
+ 	if(_setting){
+@@ -300,18 +307,29 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 	v6.lastLine = v6.startIps.length - 1
+ 	v4.firstIp = v4.startIps[0]
+ 	v6.firstIp = v6.startIps[0]
+-	if(curSetting.isCity){
+-		LocBuffer = locBuffer
+-		CityNameBuffer = cityNameBuffer
+-		if(subBuffer){
+-			var tmpJson = JSON.parse(subBuffer)
+-			if(locFieldHash.region1_name) Region1NameJson = tmpJson.region1_name
+-			if(locFieldHash.region2_name) Region2NameJson = tmpJson.region2_name
+-			if(locFieldHash.timezone) TimezoneJson = tmpJson.timezone
+-			if(mainFieldHash.area) AreaJson = tmpJson.area
+-			if(locFieldHash.eu) EuJson = tmpJson.eu
+-		}
+-	}
++        var tmpJson
++        if(subBuffer){
++                tmpJson = JSON.parse(subBuffer)
++                if(tmpJson.longPostcode){
++                        LongPostcodeJson = tmpJson.longPostcode
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
++        } else if(mainFieldHash.postcode){
++                LongPostcodeJson = null
++        }
++
++        if(curSetting.isCity){
++                LocBuffer = locBuffer
++                CityNameBuffer = cityNameBuffer
++                if(tmpJson){
++                        if(locFieldHash.region1_name) Region1NameJson = tmpJson.region1_name
++                        if(locFieldHash.region2_name) Region2NameJson = tmpJson.region2_name
++                        if(locFieldHash.timezone) TimezoneJson = tmpJson.timezone
++                        if(mainFieldHash.area) AreaJson = tmpJson.area
++                        if(locFieldHash.eu) EuJson = tmpJson.eu
++                }
++        }
+ 
+ 	// To avoid the error (when the database is updated while the server is running),
+ 	// we need to syncronous update the database
+@@ -530,25 +548,31 @@ const setCityRecord = (buffer, geodata, offset) => {
+ 	if(mainFieldHash.postcode){
+ 		var postcode2 = buffer.readUInt32LE(offset)
+ 		var postcode1 = buffer.readInt8(offset + 4)
+-		if (postcode2) {
+-			var postcode, tmp
+-			if(postcode1 < -9){
+-				tmp = (-postcode1).toString()
+-				postcode = postcode2.toString(36)
+-				postcode = getZeroFill(postcode.slice(0, -tmp[1]), tmp[0]-0) + '-' + getZeroFill(postcode.slice(-tmp[1]), tmp[1]-0)
+-			} else if(postcode1 < 0){
+-				postcode = getZeroFill(postcode2.toString(36), -postcode1)
+-			} else if(postcode1 < 10){
+-				postcode = getZeroFill(postcode2.toString(10), postcode1)
+-			} else if(postcode1 < 72){
+-				postcode1 = String(postcode1)
+-				postcode = getZeroFill(postcode2.toString(10), (postcode1[0]-0) + (postcode1[1]-0))
+-				postcode = postcode.slice(0, postcode1[0]-0) + '-' + postcode.slice(postcode1[0]-0)
+-			} else {
+-				postcode = postcode1.toString(36).slice(1) + postcode2.toString(36)
+-			}
+-			geodata.postcode = postcode.toUpperCase()
+-		}
++        if (postcode2) {
++                var postcode, tmp
++                if(postcode1 < -9){
++                        tmp = (-postcode1).toString()
++                        postcode = postcode2.toString(36)
++                        postcode = getZeroFill(postcode.slice(0, -tmp[1]), tmp[0]-0) + '-' + getZeroFill(postcode.slice(-tmp[1]), tmp[1]-0)
++                } else if(postcode1 < 0){
++                        postcode = getZeroFill(postcode2.toString(36), -postcode1)
++                } else if(postcode1 < 10){
++                        postcode = getZeroFill(postcode2.toString(10), postcode1)
++                } else if(postcode1 < 72){
++                        postcode1 = String(postcode1)
++                        postcode = getZeroFill(postcode2.toString(10), (postcode1[0]-0) + (postcode1[1]-0))
++                        postcode = postcode.slice(0, postcode1[0]-0) + '-' + postcode.slice(postcode1[0]-0)
++                } else if(postcode1 === LONG_POSTCODE_MARKER){
++                        if(LongPostcodeJson && postcode2 < LongPostcodeJson.length){
++                                postcode = LongPostcodeJson[postcode2]
++                        }
++                } else {
++                        postcode = postcode1.toString(36).slice(1) + postcode2.toString(36)
++                }
++                if(postcode){
++                        geodata.postcode = postcode.toUpperCase()
++                }
++        }
+ 		offset += 5
+ 	}
+ 	if(mainFieldHash.area){
+diff --git a/node_modules/ip-location-api/src/main.mjs b/node_modules/ip-location-api/src/main.mjs
+index c420e47..a86100d 100644
+--- a/node_modules/ip-location-api/src/main.mjs
++++ b/node_modules/ip-location-api/src/main.mjs
+@@ -8,7 +8,7 @@ import { countries, continents } from 'countries-list'
+ import { CronJob } from 'cron'
+ 
+ import { setting, setSetting, getSettingCmd, consoleLog, consoleWarn } from './setting.mjs'
+-import { num37ToStr, getSmallMemoryFile, getZeroFill, aton6Start, aton4 } from './utils.mjs'
++import { LONG_POSTCODE_MARKER, num37ToStr, getSmallMemoryFile, getZeroFill, aton6Start, aton4 } from './utils.mjs'
+ 
+ const v4db = setting.v4
+ const v6db = setting.v6
+@@ -191,11 +191,11 @@ export const setupWithoutReload = setSetting
+  * @return {void}
+  */
+ export const clear = () => {
+-	v4db.startIps = v6db.startIps = v4db.endIps = v6db.endIps = v4db.mainBuffer = v6db.mainBuffer = null
+-	Region1NameJson = Region2NameJson = TimezoneJson = LocBuffer = CityNameBuffer = EuJson = null
++        v4db.startIps = v6db.startIps = v4db.endIps = v6db.endIps = v4db.mainBuffer = v6db.mainBuffer = null
++        Region1NameJson = Region2NameJson = TimezoneJson = LocBuffer = CityNameBuffer = EuJson = LongPostcodeJson = null
+ }
+ 
+-var Region1NameJson, Region2NameJson, TimezoneJson, LocBuffer, CityNameBuffer, AreaJson, EuJson
++var Region1NameJson, Region2NameJson, TimezoneJson, LocBuffer, CityNameBuffer, AreaJson, EuJson, LongPostcodeJson
+ var updateJob
+ /**
+  * reload in-memory database
+@@ -227,7 +227,10 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 		citySub: 		  path.join(dataDir, 'sub.json')
+ 	}
+ 
+-	var locBuffer, cityNameBuffer, subBuffer
++        const needSubFile = locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu || mainFieldHash.postcode
++        const hasSubFile = needSubFile && fsSync.existsSync(dataFiles.citySub)
++
++        var locBuffer, cityNameBuffer, subBuffer
+ 	var buffer41, buffer42, buffer43, buffer61, buffer62, buffer63
+ 	if(sync){
+ 		if(!fsSync.existsSync(dataFiles.v41)){
+@@ -243,15 +246,17 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 			buffer62 = fsSync.readFileSync(dataFiles.v62)
+ 			buffer63 = fsSync.readFileSync(dataFiles.v63)
+ 		}
+-		if(curSetting.locFile){
+-			locBuffer = fsSync.readFileSync(dataFiles.cityLocation)
+-			if(locFieldHash.city){
+-				cityNameBuffer = fsSync.readFileSync(dataFiles.cityName)
+-			}
+-			if(locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu){
+-				subBuffer = fsSync.readFileSync(dataFiles.citySub)
+-			}
+-		}
++                if(curSetting.locFile){
++                        locBuffer = fsSync.readFileSync(dataFiles.cityLocation)
++                        if(locFieldHash.city){
++                                cityNameBuffer = fsSync.readFileSync(dataFiles.cityName)
++                        }
++                }
++                if(hasSubFile){
++                        subBuffer = fsSync.readFileSync(dataFiles.citySub)
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
+ 	} else {
+ 		if(!fsSync.existsSync(dataFiles.v41)){
+ 			consoleLog('Database creating ...')
+@@ -270,16 +275,18 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 				fs.readFile(dataFiles.v63).then(data => buffer63 = data)
+ 			)
+ 		}
+-		if(curSetting.locFile){
+-			prs.push(fs.readFile(dataFiles.cityLocation).then(data => locBuffer = data))
+-			if(locFieldHash.city){
+-				prs.push(fs.readFile(dataFiles.cityName).then(data => cityNameBuffer = data))
+-			}
+-			if(locFieldHash.region1_name || locFieldHash.region2_name || locFieldHash.timezone || mainFieldHash.area || locFieldHash.eu){
+-				prs.push(fs.readFile(dataFiles.citySub).then(data => subBuffer = data))
+-			}
+-		}
+-		await Promise.all(prs)
++                if(curSetting.locFile){
++                        prs.push(fs.readFile(dataFiles.cityLocation).then(data => locBuffer = data))
++                        if(locFieldHash.city){
++                                prs.push(fs.readFile(dataFiles.cityName).then(data => cityNameBuffer = data))
++                        }
++                }
++                if(hasSubFile){
++                        prs.push(fs.readFile(dataFiles.citySub).then(data => subBuffer = data))
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
++                await Promise.all(prs)
+ 	}
+ 
+ 	if(_setting){
+@@ -299,18 +306,29 @@ export const reload = async (_setting, sync, _runningUpdate) => {
+ 	v6.lastLine = v6.startIps.length - 1
+ 	v4.firstIp = v4.startIps[0]
+ 	v6.firstIp = v6.startIps[0]
+-	if(curSetting.isCity){
+-		LocBuffer = locBuffer
+-		CityNameBuffer = cityNameBuffer
+-		if(subBuffer){
+-			var tmpJson = JSON.parse(subBuffer)
+-			if(locFieldHash.region1_name) Region1NameJson = tmpJson.region1_name
+-			if(locFieldHash.region2_name) Region2NameJson = tmpJson.region2_name
+-			if(locFieldHash.timezone) TimezoneJson = tmpJson.timezone
+-			if(mainFieldHash.area) AreaJson = tmpJson.area
+-			if(locFieldHash.eu) EuJson = tmpJson.eu
+-		}
+-	}
++        var tmpJson
++        if(subBuffer){
++                tmpJson = JSON.parse(subBuffer)
++                if(tmpJson.longPostcode){
++                        LongPostcodeJson = tmpJson.longPostcode
++                } else if(mainFieldHash.postcode){
++                        LongPostcodeJson = null
++                }
++        } else if(mainFieldHash.postcode){
++                LongPostcodeJson = null
++        }
++
++        if(curSetting.isCity){
++                LocBuffer = locBuffer
++                CityNameBuffer = cityNameBuffer
++                if(tmpJson){
++                        if(locFieldHash.region1_name) Region1NameJson = tmpJson.region1_name
++                        if(locFieldHash.region2_name) Region2NameJson = tmpJson.region2_name
++                        if(locFieldHash.timezone) TimezoneJson = tmpJson.timezone
++                        if(mainFieldHash.area) AreaJson = tmpJson.area
++                        if(locFieldHash.eu) EuJson = tmpJson.eu
++                }
++        }
+ 
+ 	// To avoid the error (when the database is updated while the server is running),
+ 	// we need to syncronous update the database
+@@ -514,25 +532,31 @@ const setCityRecord = (buffer, geodata, offset) => {
+ 	if(mainFieldHash.postcode){
+ 		var postcode2 = buffer.readUInt32LE(offset)
+ 		var postcode1 = buffer.readInt8(offset + 4)
+-		if (postcode2) {
+-			var postcode, tmp
+-			if(postcode1 < -9){
+-				tmp = (-postcode1).toString()
+-				postcode = postcode2.toString(36)
+-				postcode = getZeroFill(postcode.slice(0, -tmp[1]), tmp[0]-0) + '-' + getZeroFill(postcode.slice(-tmp[1]), tmp[1]-0)
+-			} else if(postcode1 < 0){
+-				postcode = getZeroFill(postcode2.toString(36), -postcode1)
+-			} else if(postcode1 < 10){
+-				postcode = getZeroFill(postcode2.toString(10), postcode1)
+-			} else if(postcode1 < 72){
+-				postcode1 = String(postcode1)
+-				postcode = getZeroFill(postcode2.toString(10), (postcode1[0]-0) + (postcode1[1]-0))
+-				postcode = postcode.slice(0, postcode1[0]-0) + '-' + postcode.slice(postcode1[0]-0)
+-			} else {
+-				postcode = postcode1.toString(36).slice(1) + postcode2.toString(36)
+-			}
+-			geodata.postcode = postcode.toUpperCase()
+-		}
++                if (postcode2) {
++                        var postcode, tmp
++                        if(postcode1 < -9){
++                                tmp = (-postcode1).toString()
++                                postcode = postcode2.toString(36)
++                                postcode = getZeroFill(postcode.slice(0, -tmp[1]), tmp[0]-0) + '-' + getZeroFill(postcode.slice(-tmp[1]), tmp[1]-0)
++                        } else if(postcode1 < 0){
++                                postcode = getZeroFill(postcode2.toString(36), -postcode1)
++                        } else if(postcode1 < 10){
++                                postcode = getZeroFill(postcode2.toString(10), postcode1)
++                        } else if(postcode1 < 72){
++                                postcode1 = String(postcode1)
++                                postcode = getZeroFill(postcode2.toString(10), (postcode1[0]-0) + (postcode1[1]-0))
++                                postcode = postcode.slice(0, postcode1[0]-0) + '-' + postcode.slice(postcode1[0]-0)
++                        } else if(postcode1 === LONG_POSTCODE_MARKER){
++                                if(LongPostcodeJson && postcode2 < LongPostcodeJson.length){
++                                        postcode = LongPostcodeJson[postcode2]
++                                }
++                        } else {
++                                postcode = postcode1.toString(36).slice(1) + postcode2.toString(36)
++                        }
++                        if(postcode){
++                                geodata.postcode = postcode.toUpperCase()
++                        }
++                }
+ 		offset += 5
+ 	}
+ 	if(mainFieldHash.area){
+diff --git a/node_modules/ip-location-api/src/utils.mjs b/node_modules/ip-location-api/src/utils.mjs
+index ee83911..f3e4d44 100644
+--- a/node_modules/ip-location-api/src/utils.mjs
++++ b/node_modules/ip-location-api/src/utils.mjs
+@@ -3,6 +3,7 @@ import path from 'path'
+ // export const DEBUG = process.argv.includes('debug')
+ 
+ //export const MaxLocationId = 0xFFFFFFFF - 26*26
++export const LONG_POSTCODE_MARKER = -128
+ export const countryCodeToNum = (code) => { // 0~675
+ 	code = code.toUpperCase()
+ 	return (code.charCodeAt(0)-65)*26 + (code.charCodeAt(1)-65)
+@@ -155,7 +156,8 @@ const isPostNumReg2 = /^(\d+)[-\s](\d+)$/
+ const isPostStrReg = /^([A-Z\d]+)$/
+ const isPostStrReg2 = /^([A-Z\d]+)[-\s]([A-Z\d]+)$/
+ export const getPostcodeDatabase = (postcode) => {
+-	if(!postcode) return [0, 0];
++        if(!postcode) return [0, 0];
++        postcode = postcode.toUpperCase();
+ 	// number type
+ 	if(isPostNumReg.test(postcode)){
+ 		return [


### PR DESCRIPTION
## Summary
- add patch-package support so a custom ip-location-api fix is applied after installs
- patch ip-location-api to encode long postcodes via a dedicated dictionary and load them during reload to avoid UInt32 overflow during database updates

## Testing
- `npm --prefix backend run build` *(fails: existing TypeScript errors in project controller unrelated to postcode fix)*

------
https://chatgpt.com/codex/tasks/task_e_68fe0aa03dc4832b8035f65ac37767db