### PR TITLE
Add localization support for Chrome extension popup

### DIFF
--- a/chrome-extension/_locales/en/messages.json
+++ b/chrome-extension/_locales/en/messages.json
@@ -1,0 +1,32 @@
+{
+  "appTitle": {
+    "message": "rflnk"
+  },
+  "loginEmailPlaceholder": {
+    "message": "Email"
+  },
+  "loginPasswordPlaceholder": {
+    "message": "Password"
+  },
+  "loginButton": {
+    "message": "Login"
+  },
+  "createLinkNamePlaceholder": {
+    "message": "Link name"
+  },
+  "createLinkUrlPlaceholder": {
+    "message": "Destination URL"
+  },
+  "createButton": {
+    "message": "Create Link"
+  },
+  "loginFailed": {
+    "message": "Login failed"
+  },
+  "createLinkFailed": {
+    "message": "Failed to create link"
+  },
+  "shortLinkCopied": {
+    "message": "Short link copied to clipboard: $1"
+  }
+}

--- a/chrome-extension/_locales/fr/messages.json
+++ b/chrome-extension/_locales/fr/messages.json
@@ -1,0 +1,32 @@
+{
+  "appTitle": {
+    "message": "rflnk"
+  },
+  "loginEmailPlaceholder": {
+    "message": "Courriel"
+  },
+  "loginPasswordPlaceholder": {
+    "message": "Mot de passe"
+  },
+  "loginButton": {
+    "message": "Connexion"
+  },
+  "createLinkNamePlaceholder": {
+    "message": "Nom du lien"
+  },
+  "createLinkUrlPlaceholder": {
+    "message": "URL de destination"
+  },
+  "createButton": {
+    "message": "Créer un lien"
+  },
+  "loginFailed": {
+    "message": "Échec de la connexion"
+  },
+  "createLinkFailed": {
+    "message": "Échec de la création du lien"
+  },
+  "shortLinkCopied": {
+    "message": "Lien court copié dans le presse-papiers : $1"
+  }
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -3,6 +3,7 @@
   "name": "rflnk Quick Link",
   "version": "0.1.0",
   "description": "Create rflnk links directly from your browser.",
+  "default_locale": "en",
   "permissions": ["storage", "activeTab", "scripting", "contextMenus", "clipboardWrite", "notifications"],
   "host_permissions": ["https://rflnk.com/*"],
   "background": {

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>rflnk</title>
+  <title data-i18n-text="appTitle"></title>
   <style>
     body { font-family: sans-serif; padding: 10px; width: 300px; }
     input, button { width: 100%; margin-bottom: 8px; }
@@ -10,16 +10,16 @@
 </head>
 <body>
   <div id="login">
-    <input id="email" type="email" placeholder="Email" />
-    <input id="password" type="password" placeholder="Password" />
-    <button id="loginBtn">Login</button>
+    <input id="email" type="email" data-i18n-placeholder="loginEmailPlaceholder" />
+    <input id="password" type="password" data-i18n-placeholder="loginPasswordPlaceholder" />
+    <button id="loginBtn" type="button" data-i18n-text="loginButton"></button>
   </div>
   <div id="create" style="display:none">
-    <input id="name" placeholder="Link name" />
-    <input id="url" placeholder="Destination URL" />
-    <button id="createBtn">Create Link</button>
+    <input id="name" data-i18n-placeholder="createLinkNamePlaceholder" />
+    <input id="url" data-i18n-placeholder="createLinkUrlPlaceholder" />
+    <button id="createBtn" type="button" data-i18n-text="createButton"></button>
   </div>
-  <div id="result" style="display:none"></div>
+  <div id="result" style="display:none" role="status" aria-live="polite"></div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -23,12 +23,35 @@ async function apiRequest(endpoint, method, data) {
   return json.data;
 }
 
+function localizePopup() {
+  const title = chrome.i18n.getMessage('appTitle');
+  if (title) {
+    document.title = title;
+  }
+
+  document.querySelectorAll('[data-i18n-text]').forEach(el => {
+    const messageName = el.dataset.i18nText;
+    if (messageName) {
+      el.textContent = chrome.i18n.getMessage(messageName);
+    }
+  });
+
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    const messageName = el.dataset.i18nPlaceholder;
+    if (messageName) {
+      el.placeholder = chrome.i18n.getMessage(messageName);
+    }
+  });
+}
+
 function showCreate() {
   document.getElementById('login').style.display = 'none';
   document.getElementById('create').style.display = 'block';
 }
 
 async function init() {
+  localizePopup();
+
   const token = await getStored('token');
   if (token) showCreate();
 
@@ -48,7 +71,7 @@ async function init() {
       if (projects.length) await setStored({ projectId: projects[0].id });
       showCreate();
     } catch (e) {
-      alert('Login failed');
+      alert(chrome.i18n.getMessage('loginFailed'));
     }
   };
 
@@ -58,11 +81,12 @@ async function init() {
     try {
       const link = await apiRequest('/links', 'POST', { name, baseUrl: url, shortCode: '' });
       const shortUrl = `https://rflnk.com/l/${link.shortCode}`;
-      document.getElementById('result').textContent = shortUrl;
-      document.getElementById('result').style.display = 'block';
       await navigator.clipboard.writeText(shortUrl);
+      const resultEl = document.getElementById('result');
+      resultEl.textContent = chrome.i18n.getMessage('shortLinkCopied', shortUrl);
+      resultEl.style.display = 'block';
     } catch (e) {
-      alert('Failed to create link');
+      alert(chrome.i18n.getMessage('createLinkFailed'));
     }
   };
 }


### PR DESCRIPTION
## Summary
- add English and French locale message files for the popup interface, including alerts and clipboard feedback
- set the extension default locale and tag popup markup with i18n data attributes
- load localized strings in the popup script so placeholders, buttons, and status messages use chrome.i18n

## Testing
- not run (manual Chrome verification required)


------
https://chatgpt.com/codex/tasks/task_e_68fe2eceb34c832bbaa13077d885f949