### PR TITLE
Add migration for locale columns on user and project

### DIFF
--- a/backend/prisma/migrations/20251120120000_add_locale_columns/migration.sql
+++ b/backend/prisma/migrations/20251120120000_add_locale_columns/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE `User`
+    ADD COLUMN `locale` VARCHAR(191) NULL DEFAULT 'en';
+
+ALTER TABLE `Project`
+    ADD COLUMN `locale` VARCHAR(191) NULL DEFAULT 'en';


### PR DESCRIPTION
## Summary
- add a Prisma migration that adds the missing `locale` columns to the `User` and `Project` tables
- ensure existing login flows can read the locale without Prisma throwing P2022 errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe3e1a09b8832bbaacd390fd64f3fe