### PR TITLE
feat: replace referral terminology with links

### DIFF
--- a/frontend/src/hooks/use-tips.ts
+++ b/frontend/src/hooks/use-tips.ts
@@ -20,7 +20,7 @@ const APP_TIPS: Tip[] = [
   //   {
   //     id: "project-setup",
   //     title: "Create your first project",
-  //     summary: "Start by creating a project to organize your referral links.",
+  //     summary: "Start by creating a project to organize your links.",
   //     image: "/images/tips/project.png",
   //   },
   // {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -303,17 +303,17 @@
     }
   },
   "links": {
-    "title_list": "Referral Links",
+    "title_list": "Links",
     "title_create": "Create Link",
     "title_edit": "Edit Link",
     "breadcrumb": {
-      "list": "Referral Links",
+      "list": "Links",
       "create": "Create Link",
       "edit": "Edit Link"
     },
     "empty": {
       "title": "No links available",
-      "description": "Create your first referral link to start seeing analytics"
+      "description": "Create your first link to start seeing analytics"
     },
     "errors": {
       "load": "Failed to load links data",
@@ -336,7 +336,7 @@
     "form": {
       "basic": {
         "title": "Basic Settings",
-        "description": "Configure the essential information for your referral link.",
+        "description": "Configure the essential information for your link.",
         "name_label": "Link name",
         "name_placeholder": "Summer campaign",
         "url_label": "Destination URL",
@@ -453,7 +453,7 @@
           "cpc": "CPC",
           "display": "Display",
           "affiliate": "Affiliate",
-          "referral": "Referral",
+          "referral": "Recommendation",
           "organic": "Organic"
         },
         "preview_label": "Preview URL"
@@ -513,12 +513,12 @@
       }
     },
     "list": {
-      "title": "Referral Links",
+      "title": "Links",
       "empty_title": "No links",
-      "empty_description": "Start by creating your first referral link",
+      "empty_description": "Start by creating your first link",
       "create": "Create link",
       "name": "Name",
-      "referral_url": "Referral URL",
+      "referral_url": "Link URL",
       "short_url": "Short URL",
       "clicks": "Clicks",
       "created_at": "Creation date",
@@ -545,10 +545,10 @@
     "error_title": "Error",
     "error_description": "Please try again later or contact support if the issue persists.",
     "empty_title": "No analytics data available",
-    "empty_description": "Create your first referral link to start seeing analytics",
+    "empty_description": "Create your first link to start seeing analytics",
     "header": {
       "title": "Links Performance",
-      "subtitle": "Statistics and performance of all your referral links.",
+      "subtitle": "Statistics and performance of all your links.",
       "total_clicks": "Total Clicks",
       "number_of_links": "Number of Links"
     },

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -303,11 +303,11 @@
     }
   },
   "links": {
-    "title_list": "Liens de parrainage",
+    "title_list": "Liens",
     "title_create": "Créer un lien",
     "title_edit": "Modifier le lien",
     "breadcrumb": {
-      "list": "Liens de parrainage",
+      "list": "Liens",
       "create": "Créer un lien",
       "edit": "Modifier le lien"
     },
@@ -453,7 +453,7 @@
           "cpc": "CPC",
           "display": "Display",
           "affiliate": "Affiliation",
-          "referral": "Parrainage",
+          "referral": "Recommandation",
           "organic": "Naturel"
         },
         "preview_label": "URL de prévisualisation"
@@ -513,12 +513,12 @@
       }
     },
     "list": {
-      "title": "Liens de parrainage",
+      "title": "Liens",
       "empty_title": "Aucun lien",
-      "empty_description": "Commencez par créer votre premier lien de parrainage",
+      "empty_description": "Commencez par créer votre premier lien",
       "create": "Créer un lien",
       "name": "Nom",
-      "referral_url": "URL de parrainage",
+      "referral_url": "URL du lien",
       "short_url": "URL courte",
       "clicks": "Clics",
       "created_at": "Date de création",
@@ -548,7 +548,7 @@
     "empty_description": "Créez votre premier lien pour visualiser des statistiques",
     "header": {
       "title": "Performance des liens",
-      "subtitle": "Statistiques et performances de tous vos liens de parrainage.",
+      "subtitle": "Statistiques et performances de tous vos liens.",
       "total_clicks": "Clics totaux",
       "number_of_links": "Nombre de liens"
     },


### PR DESCRIPTION
## Summary
- rename the French link management strings to remove "parrainage" terminology
- update the English locale so link-related labels no longer mention referrals
- adjust an unused tip summary comment to reference generic links

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe3f542948832bad1d9868f173c69b