### PR TITLE
Fix dashboard top links card click count

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { LineChart } from "@/components/ui/charts";
 import { Link } from "react-router-dom";
-import { ReferralLink } from "./types";
+import { TopLinkSummary } from "./types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Project, api } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -72,7 +72,7 @@ export default function HomePage() {
     totalClicks: 0,
     recentClicks: [],
   });
-  const [topLinks, setTopLinks] = useState<ReferralLink[]>([]);
+  const [topLinks, setTopLinks] = useState<TopLinkSummary[]>([]);
   const [projectDetails, setProjectDetails] = useState<Project | null>(null);
 
   const fetchDashboardData = async () => {
@@ -87,47 +87,33 @@ export default function HomePage() {
       setError(null);
 
       // Charger les statistiques du projet et les informations détaillées
-      const [projectStats, projectInfo] = await Promise.all([
+      const [projectStats, projectInfo, dashboardStats] = await Promise.all([
         api.getProjectStats(currentProjectId, "week"),
         api.getProject(currentProjectId),
+        api.getDashboardStats(currentProjectId),
       ]);
       setProjectDetails(projectInfo);
 
-      try {
-        // Charger les liens - traité séparément pour éviter qu'une erreur ici
-        // n'empêche l'affichage des autres données
-        const linksResponse = await api.getLinks(
-          currentProjectId,
-          1,
-          "clicks",
-          "desc"
-        );
+      setStats({
+        totalLinks: dashboardStats?.totalLinks ?? 0,
+        totalClicks: dashboardStats?.totalVisits ?? projectStats.totalVisits,
+        recentClicks: projectStats.visitsByDate.map((item) => ({
+          date: new Date(item.date).toLocaleDateString(),
+          count: item.count,
+        })),
+      });
 
-        setStats({
-          totalLinks: linksResponse?.links?.length || 0,
-          totalClicks: projectStats.totalVisits,
-          recentClicks: projectStats.visitsByDate.map((item) => ({
-            date: new Date(item.date).toLocaleDateString(),
-            count: item.count,
-          })),
-        });
+      const formattedTopLinks = (dashboardStats?.topLinks || [])
+        .map(({ linkId, visits, details }) => ({
+          id: details?.id ?? linkId,
+          name: details?.name ?? `Link #${linkId}`,
+          shortCode: details?.shortCode ?? String(linkId),
+          baseUrl: details?.baseUrl,
+          visits,
+        }))
+        .slice(0, 5);
 
-        // Récupérer les 5 meilleurs liens
-        setTopLinks(linksResponse?.links?.slice(0, 5) || []);
-      } catch (linkError) {
-        console.error("Erreur lors du chargement des liens:", linkError);
-
-        // On continue avec les statistiques mais sans les données de liens
-        setStats({
-          totalLinks: 0,
-          totalClicks: projectStats.totalVisits,
-          recentClicks: projectStats.visitsByDate.map((item) => ({
-            date: new Date(item.date).toLocaleDateString(),
-            count: item.count,
-          })),
-        });
-        setTopLinks([]);
-      }
+      setTopLinks(formattedTopLinks);
     } catch (error) {
       console.error(
         "Erreur lors du chargement des données du tableau de bord:",
@@ -156,6 +142,12 @@ export default function HomePage() {
         }
       }
 
+      setStats({
+        totalLinks: 0,
+        totalClicks: 0,
+        recentClicks: [],
+      });
+      setTopLinks([]);
       setError(errorMessage);
       setProjectDetails(null);
     } finally {
@@ -460,13 +452,15 @@ export default function HomePage() {
                       className="flex items-center justify-between p-3 transition-colors rounded-md bg-white/10 backdrop-blur-md hover:bg-white/20"
                     >
                       <div className="mr-4 truncate">
-                        <p className="font-medium truncate">{link.name}</p>
+                        <p className="font-medium truncate">
+                          {link.name || `Link #${link.id}`}
+                        </p>
                         <p className="text-sm truncate text-muted-foreground">
-                          /{link.shortCode}
+                          /{link.shortCode || link.id}
                         </p>
                       </div>
                       <div className="text-sm font-medium ">
-                        {link?._count?.LinkVisit} clicks
+                        {link.visits.toLocaleString()} clicks
                       </div>
                     </div>
                   ))}

--- a/frontend/src/pages/types.ts
+++ b/frontend/src/pages/types.ts
@@ -18,6 +18,14 @@ export interface ReferralLink {
   };
 }
 
+export interface TopLinkSummary {
+  id: number;
+  name: string;
+  shortCode: string;
+  visits: number;
+  baseUrl?: string;
+}
+
 export interface CountryVisit {
   country: string;
   count: number;


### PR DESCRIPTION
## Summary
- load dashboard statistics to populate the home page top links list
- map API results into a lightweight summary model for rendering
- display the cached visit total for each link instead of an empty count

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe404d5e64832b9d8e0d6cab21c5fc