### PR TITLE
Add link expiration support to backend and UI

### DIFF
--- a/backend/prisma/migrations/20250304120000_add_link_expiration/migration.sql
+++ b/backend/prisma/migrations/20250304120000_add_link_expiration/migration.sql
@@ -1,0 +1,5 @@
+-- Add optional expiration date to links
+ALTER TABLE `Link`
+    ADD COLUMN `expiresAt` DATETIME(3) NULL;
+
+CREATE INDEX `Link_expiresAt_idx` ON `Link`(`expiresAt`);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Link {
     active              Boolean      @default(true)
     isPasswordProtected Boolean      @default(false)
     passwordHash        String?
+    expiresAt           DateTime?
     // UTM Parameters
     utmSource           String?
     utmMedium           String?
@@ -89,6 +90,7 @@ model Link {
     LinkVisit           LinkVisit[]
 
     @@index([projectId])
+    @@index([expiresAt])
 }
 
 model LinkRule {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -257,6 +257,7 @@ async function main() {
       shortCode: "fb25",
       projectId: socialProject.id,
       active: true,
+      expiresAt: new Date(Date.now() + 45 * 24 * 60 * 60 * 1000),
     },
   });
 
@@ -288,6 +289,7 @@ async function main() {
       shortCode: "expired",
       projectId: marketingProject.id,
       active: false,
+      expiresAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
       rules: {
         create: {
           redirectUrl: "https://example.com/expired/campaign",

--- a/backend/src/controllers/link.ts
+++ b/backend/src/controllers/link.ts
@@ -198,6 +198,7 @@ export const createLink = async (req: Request, res: Response) => {
       utmCampaign,
       utmTerm,
       utmContent,
+      expiresAt,
     } = req.body;
     const projectId = parseInt(
       req.params.projectId || (req.headers["x-project-id"] as string)
@@ -219,6 +220,20 @@ export const createLink = async (req: Request, res: Response) => {
         return res.status(400).json({
           error: "Password must be at least 6 characters long",
         });
+      }
+    }
+
+    // Parse optional expiration date
+    let expiresAtValue: Date | null | undefined;
+    if (typeof expiresAt !== "undefined") {
+      if (expiresAt === null || expiresAt === "") {
+        expiresAtValue = null;
+      } else {
+        const parsedDate = new Date(expiresAt);
+        if (isNaN(parsedDate.getTime())) {
+          return res.status(400).json({ error: "Invalid expiration date" });
+        }
+        expiresAtValue = parsedDate;
       }
     }
 
@@ -264,6 +279,9 @@ export const createLink = async (req: Request, res: Response) => {
         utmCampaign,
         utmTerm,
         utmContent,
+        ...(typeof expiresAtValue !== "undefined"
+          ? { expiresAt: expiresAtValue }
+          : {}),
       },
     });
 
@@ -359,6 +377,7 @@ export const updateLink = async (req: Request, res: Response) => {
       utmCampaign,
       utmTerm,
       utmContent,
+      expiresAt,
     } = req.body;
     const userId = req.user?.id;
     const isAdmin = req.user?.role === "ADMIN";
@@ -424,6 +443,21 @@ export const updateLink = async (req: Request, res: Response) => {
       };
     }
 
+    let expiresAtValue: Date | null | undefined;
+    if (typeof expiresAt !== "undefined") {
+      if (expiresAt === null || expiresAt === "") {
+        expiresAtValue = null;
+      } else {
+        const parsedDate = new Date(expiresAt);
+        if (isNaN(parsedDate.getTime())) {
+          return res
+            .status(400)
+            .json({ error: "Invalid expiration date" });
+        }
+        expiresAtValue = parsedDate;
+      }
+    }
+
     // Update link basic information including UTM parameters
     const updatedLink = await prisma.link.update({
       where: { id: parseInt(id) },
@@ -437,6 +471,9 @@ export const updateLink = async (req: Request, res: Response) => {
         utmCampaign,
         utmTerm,
         utmContent,
+        ...(typeof expiresAtValue !== "undefined"
+          ? { expiresAt: expiresAtValue }
+          : {}),
       },
     });
 

--- a/backend/src/services/redirection.ts
+++ b/backend/src/services/redirection.ts
@@ -162,6 +162,7 @@ export const handleRedirection = async (req: Request, res: Response) => {
           id: true,
           isPasswordProtected: true,
           baseUrl: true,
+          expiresAt: true,
           rules: {
             select: {
               id: true,
@@ -189,6 +190,14 @@ export const handleRedirection = async (req: Request, res: Response) => {
       }
 
       await cacheLinkData(path, linkData);
+    }
+
+    const expirationTimestamp = linkData.expiresAt
+      ? new Date(linkData.expiresAt).getTime()
+      : null;
+
+    if (expirationTimestamp && expirationTimestamp <= Date.now()) {
+      return res.status(410).send(get404Template(translator));
     }
 
     if (linkData.isPasswordProtected) {

--- a/backend/tests/mocks/mockData.ts
+++ b/backend/tests/mocks/mockData.ts
@@ -4,6 +4,7 @@ export const mockLinkData = {
   baseUrl: "example.com",
   active: true,
   isPasswordProtected: false,
+  expiresAt: null as string | null,
   rules: [
     {
       id: "1",

--- a/backend/tests/services/redirection.test.ts
+++ b/backend/tests/services/redirection.test.ts
@@ -156,6 +156,25 @@ describe("Redirection Service Tests", () => {
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
+    test("returns 410 when the link has expired", async () => {
+      const expiredLinkData = {
+        ...mockLinkData,
+        expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+      };
+
+      const req = createMockRequest({}) as Request;
+      const res = createMockResponse() as Response;
+
+      mockRedis.setupCacheHit("testlink", expiredLinkData);
+      mockGeolocation.setup("US");
+      mockPrisma.setupFindLink(expiredLinkData);
+
+      await handleRedirection(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(410);
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+
     test("uses baseUrl when no rules match", async () => {
       const req = createMockRequest({}) as Request;
       const res = createMockResponse() as Response;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -467,6 +467,15 @@
         "show": "Show",
         "hide": "Hide"
       },
+      "time_expire": {
+        "title": "Link expiration",
+        "description": "Disable this link automatically after the selected date and time.",
+        "enable_label": "Enable link expiration",
+        "date_label": "Expiration date and time",
+        "placeholder": "Select a date and time",
+        "timezone_note": "The expiration uses your current timezone.",
+        "clear": "Remove expiration"
+      },
       "preview": {
         "title": "Link Preview",
         "loading": "Generating preview...",
@@ -479,6 +488,10 @@
         "utm_parameters": "UTM Parameters",
         "takes_precedence": "Takes precedence",
         "custom_countries": "Custom Countries",
+        "expiration": {
+          "active": "Expires on {{date}}",
+          "expired": "Expired on {{date}}"
+        },
         "utm_labels": {
           "source": "Source",
           "medium": "Medium",
@@ -494,19 +507,20 @@
       "tabs": {
         "geo": "Geo Targeting",
         "device": "Device",
-        "time_expire": "Time Expire",
+        "time_expire": "Expiration",
         "time_start": "Time Start",
         "password": "Password Protection",
         "utm": "UTM"
       },
       "coming_soon": {
-        "time_expire": "Time expiry coming soon",
         "time_start": "Time start coming soon"
       },
       "errors": {
         "missing_required": "Base URL and name are required",
         "shortcode": "A valid short code is required",
-        "password": "Password must be at least 6 characters long when password protection is enabled"
+        "password": "Password must be at least 6 characters long when password protection is enabled",
+        "expiration_required": "Select an expiration date before enabling this option",
+        "expiration_invalid": "Enter a valid expiration date"
       },
       "messages": {
         "fetch_error": "Failed to fetch link data"
@@ -522,6 +536,7 @@
       "short_url": "Short URL",
       "clicks": "Clicks",
       "created_at": "Creation date",
+      "expiration": "Expiration",
       "actions": "Actions",
       "copy": "Copy link",
       "copy_success": "Link copied to clipboard",
@@ -536,7 +551,10 @@
       "cancel": "Cancel",
       "page_info": "Page {{current}} of {{total}}",
       "previous": "Previous page",
-      "next": "Next page"
+      "next": "Next page",
+      "no_expiration": "No expiration",
+      "expired": "Expired",
+      "expires_badge": "Scheduled"
     }
   },
   "analytics": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -467,6 +467,15 @@
         "show": "Afficher",
         "hide": "Masquer"
       },
+      "time_expire": {
+        "title": "Expiration du lien",
+        "description": "Désactivez automatiquement ce lien après la date et l'heure sélectionnées.",
+        "enable_label": "Activer l'expiration du lien",
+        "date_label": "Date et heure d'expiration",
+        "placeholder": "Sélectionnez une date et une heure",
+        "timezone_note": "L'expiration utilise votre fuseau horaire actuel.",
+        "clear": "Supprimer l'expiration"
+      },
       "preview": {
         "title": "Aperçu du lien",
         "loading": "Génération de l'aperçu...",
@@ -479,6 +488,10 @@
         "utm_parameters": "Paramètres UTM",
         "takes_precedence": "Prioritaire",
         "custom_countries": "Pays personnalisés",
+        "expiration": {
+          "active": "Expire le {{date}}",
+          "expired": "Expiré le {{date}}"
+        },
         "utm_labels": {
           "source": "Source",
           "medium": "Support",
@@ -500,13 +513,14 @@
         "utm": "UTM"
       },
       "coming_soon": {
-        "time_expire": "Expiration prochainement",
         "time_start": "Activation prochainement"
       },
       "errors": {
         "missing_required": "L'URL de base et le nom sont obligatoires",
         "shortcode": "Un code court valide est requis",
-        "password": "Le mot de passe doit contenir au moins 6 caractères lorsque la protection est activée"
+        "password": "Le mot de passe doit contenir au moins 6 caractères lorsque la protection est activée",
+        "expiration_required": "Sélectionnez une date d'expiration avant d'activer cette option",
+        "expiration_invalid": "Saisissez une date d'expiration valide"
       },
       "messages": {
         "fetch_error": "Impossible de récupérer les données du lien"
@@ -522,6 +536,7 @@
       "short_url": "URL courte",
       "clicks": "Clics",
       "created_at": "Date de création",
+      "expiration": "Expiration",
       "actions": "Actions",
       "copy": "Copier le lien",
       "copy_success": "Lien copié dans le presse-papiers",
@@ -536,7 +551,10 @@
       "cancel": "Annuler",
       "page_info": "Page {{current}} sur {{total}}",
       "previous": "Page précédente",
-      "next": "Page suivante"
+      "next": "Page suivante",
+      "no_expiration": "Pas d'expiration",
+      "expired": "Expiré",
+      "expires_badge": "Planifié"
     }
   },
   "analytics": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -354,6 +354,7 @@ class Api {
       utmCampaign?: string;
       utmTerm?: string;
       utmContent?: string;
+      expiresAt?: string | null;
     }
   ): Promise<ApiResponse<ReferralLink>> {
     const transformedData = {
@@ -373,6 +374,7 @@ class Api {
       utmCampaign: data.utmCampaign,
       utmTerm: data.utmTerm,
       utmContent: data.utmContent,
+      expiresAt: data.expiresAt,
     };
     return this.put<ReferralLink>(`/links/${linkId}`, transformedData);
   }
@@ -392,6 +394,7 @@ class Api {
       utmCampaign?: string;
       utmTerm?: string;
       utmContent?: string;
+      expiresAt?: string | null;
     }
   ): Promise<ApiResponse<ReferralLink>> {
     const transformedData = {
@@ -410,6 +413,7 @@ class Api {
       utmCampaign: data.utmCampaign,
       utmTerm: data.utmTerm,
       utmContent: data.utmContent,
+      expiresAt: data.expiresAt,
     };
     return this.post<ReferralLink>("/links", transformedData, projectId);
   }

--- a/frontend/src/pages/LinksPage.tsx
+++ b/frontend/src/pages/LinksPage.tsx
@@ -86,6 +86,14 @@ export default function LinksPage() {
           countries: rule.countries,
         })),
         deviceRules: formData.deviceRules,
+        isPasswordProtected: formData.isPasswordProtected,
+        password: formData.password,
+        utmSource: formData.utmSource,
+        utmMedium: formData.utmMedium,
+        utmCampaign: formData.utmCampaign,
+        utmTerm: formData.utmTerm,
+        utmContent: formData.utmContent,
+        expiresAt: formData.expiresAt,
       };
 
       if (formData.id) {

--- a/frontend/src/pages/links/AddLinkForm.tsx
+++ b/frontend/src/pages/links/AddLinkForm.tsx
@@ -23,6 +23,7 @@ import { GeoTargeting } from "./AddLinkForm/GeoTargeting";
 import { LinkPreview } from "./LinkPreview";
 import { PasswordProtection } from "@/components/links/PasswordProtection";
 import { UTMParameters } from "./AddLinkForm/UTMParameters";
+import { ExpirationSettings } from "./AddLinkForm/ExpirationSettings";
 import { api } from "@/lib/api";
 import { detectRegionFromCountries } from "./utils";
 import { generateRandomCode } from "./AddLinkForm/utils";
@@ -52,6 +53,7 @@ interface AddLinkFormProps {
     utmCampaign?: string;
     utmTerm?: string;
     utmContent?: string;
+    expiresAt?: string | null;
   };
   mode?: "add" | "edit";
 }
@@ -59,6 +61,33 @@ interface AddLinkFormProps {
 export interface AddLinkFormRef {
   getFormData: () => LinkFormData;
 }
+
+const toDateTimeLocalString = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+};
+
+const fromDateTimeLocalString = (value: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+};
+
+const getDefaultExpirationInput = () => {
+  const now = new Date();
+  const fallback = new Date(now.getTime() + 60 * 60 * 1000);
+  const offset = fallback.getTimezoneOffset();
+  const local = new Date(fallback.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+};
 
 export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
   ({ initialData }, ref) => {
@@ -93,6 +122,12 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
       initialData?.isPasswordProtected || false
     );
     const [password, setPassword] = useState("");
+    const [isExpirationEnabled, setIsExpirationEnabled] = useState(
+      Boolean(initialData?.expiresAt)
+    );
+    const [expirationDate, setExpirationDate] = useState<string | null>(
+      initialData?.expiresAt ? toDateTimeLocalString(initialData.expiresAt) : null
+    );
 
     const [utmParameters, setUtmParameters] = useState<UTMParametersType>({
       utmSource: initialData?.utmSource || "",
@@ -176,6 +211,11 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
                 }))
               );
             }
+
+            setIsExpirationEnabled(Boolean(data.expiresAt));
+            setExpirationDate(
+              data.expiresAt ? toDateTimeLocalString(data.expiresAt) : null
+            );
           } catch {
             toast.error(t("links.form.messages.fetch_error"));
             setGeoRules([]);
@@ -297,6 +337,24 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
             devices: rule.devices,
           }));
 
+        let expirationIso: string | null = null;
+        if (isExpirationEnabled) {
+          if (!expirationDate) {
+            const message = t("links.form.errors.expiration_required");
+            toast.error(message);
+            throw new Error(message);
+          }
+
+          const parsed = fromDateTimeLocalString(expirationDate);
+          if (!parsed) {
+            const message = t("links.form.errors.expiration_invalid");
+            toast.error(message);
+            throw new Error(message);
+          }
+
+          expirationIso = parsed;
+        }
+
         return {
           ...(isEditMode && { id }),
           name: linkName,
@@ -313,6 +371,7 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
           advanced: {
             conversionTracking: false,
           },
+          expiresAt: expirationIso,
         };
       },
     }));
@@ -341,11 +400,25 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
           );
         case 2:
           return (
-            <div className="p-4 border rounded">
-              <p className="text-muted-foreground">
-                {t("links.form.coming_soon.time_expire")}
-              </p>
-            </div>
+            <ExpirationSettings
+              enabled={isExpirationEnabled}
+              value={expirationDate}
+              onToggle={(value) => {
+                setIsExpirationEnabled(value);
+                if (value && !expirationDate) {
+                  setExpirationDate(getDefaultExpirationInput());
+                }
+                if (!value) {
+                  setExpirationDate(null);
+                }
+              }}
+              onChange={(val) => {
+                setExpirationDate(val);
+                if (val) {
+                  setIsExpirationEnabled(true);
+                }
+              }}
+            />
           );
         case 3:
           return (
@@ -420,6 +493,11 @@ export const AddLinkForm = forwardRef<AddLinkFormRef, AddLinkFormProps>(
             shortCodeUrl={`${currentDomain}/l/${shortCode}`}
             isPasswordProtected={isPasswordProtected}
             utmParameters={utmParameters}
+            expiresAt={
+              isExpirationEnabled && expirationDate
+                ? fromDateTimeLocalString(expirationDate)
+                : null
+            }
           />
         </div>
       </div>

--- a/frontend/src/pages/links/AddLinkForm/ExpirationSettings.tsx
+++ b/frontend/src/pages/links/AddLinkForm/ExpirationSettings.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useMemo } from "react";
+import { useAppTranslation } from "@/i18n";
+
+interface ExpirationSettingsProps {
+  enabled: boolean;
+  value: string | null;
+  onToggle: (value: boolean) => void;
+  onChange: (value: string | null) => void;
+}
+
+const getLocalDateTimeString = (date: Date) => {
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+};
+
+export const ExpirationSettings = ({
+  enabled,
+  value,
+  onToggle,
+  onChange,
+}: ExpirationSettingsProps) => {
+  const { t } = useAppTranslation();
+
+  const minimumValue = useMemo(() => {
+    return getLocalDateTimeString(new Date());
+  }, []);
+
+  const handleToggle = (checked: boolean) => {
+    onToggle(checked);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+  };
+
+  return (
+    <div className="space-y-4 border rounded p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label className="text-base font-medium">
+            {t("links.form.time_expire.title")}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t("links.form.time_expire.description")}
+          </p>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleToggle}
+          aria-label={t("links.form.time_expire.enable_label")}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="link-expiration" className="text-sm font-medium">
+          {t("links.form.time_expire.date_label")}
+        </Label>
+        <Input
+          id="link-expiration"
+          type="datetime-local"
+          value={value ?? ""}
+          min={minimumValue}
+          onChange={(event) => onChange(event.target.value || null)}
+          disabled={!enabled}
+          placeholder={t("links.form.time_expire.placeholder")}
+        />
+        <p className="text-xs text-muted-foreground">
+          {t("links.form.time_expire.timezone_note")}
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={handleClear}
+          disabled={!enabled || !value}
+        >
+          {t("links.form.time_expire.clear")}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/links/LinkPreview.tsx
+++ b/frontend/src/pages/links/LinkPreview.tsx
@@ -1,4 +1,4 @@
-import { Globe, Lock, Smartphone, Tag } from "lucide-react";
+import { Clock, Globe, Lock, Smartphone, Tag } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -31,6 +31,7 @@ interface LinkPreviewProps {
     utmTerm?: string;
     utmContent?: string;
   };
+  expiresAt?: string | null;
 }
 
 const regionKeyMap: Record<string, string> = {
@@ -190,11 +191,12 @@ export const LinkPreview = ({
   onLoad,
   isPasswordProtected,
   utmParameters,
+  expiresAt,
 }: LinkPreviewProps) => {
   const [debouncedLinkUrl, setDebouncedLinkUrl] = useState(linkUrl);
   const [debouncedGeoRules, setDebouncedGeoRules] = useState(geoRules);
   const [debouncedDeviceRules, setDebouncedDeviceRules] = useState(deviceRules);
-  const { t } = useAppTranslation();
+  const { t, i18n } = useAppTranslation();
 
   const getRegionLabel = (region: string) => {
     const key = regionKeyMap[region];
@@ -226,6 +228,27 @@ export const LinkPreview = ({
   const hasUtmParameters =
     utmParameters && Object.values(utmParameters).some(Boolean);
 
+  const expirationInfo = useMemo(() => {
+    if (!expiresAt) return null;
+    const date = new Date(expiresAt);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    const formatter = new Intl.DateTimeFormat(i18n.language, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    return {
+      formatted: formatter.format(date),
+      isExpired: date.getTime() <= Date.now(),
+    };
+  }, [expiresAt, i18n.language]);
+
   return (
     <>
       <div className="relative">
@@ -238,6 +261,21 @@ export const LinkPreview = ({
           onLoad={handleLoad}
           instanceId="main"
         />
+        {expirationInfo && (
+          <Badge
+            variant={expirationInfo.isExpired ? "destructive" : "secondary"}
+            className="absolute top-2 left-2 gap-1.5"
+          >
+            <Clock className="w-3 h-3" />
+            {expirationInfo.isExpired
+              ? t("links.form.preview.expiration.expired", {
+                  date: expirationInfo.formatted,
+                })
+              : t("links.form.preview.expiration.active", {
+                  date: expirationInfo.formatted,
+                })}
+          </Badge>
+        )}
         {isPasswordProtected && (
           <Badge variant="secondary" className="absolute top-2 right-2 gap-1.5">
             <Lock className="w-3 h-3" />

--- a/frontend/src/pages/links/LinksList.tsx
+++ b/frontend/src/pages/links/LinksList.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/table";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ReferralLink } from "../types";
 import { api } from "@/lib/api";
@@ -230,6 +231,66 @@ export function LinksList({
     }
   };
 
+  const formatDateTime = (dateString?: string | null) => {
+    if (!dateString) return "";
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleString(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "";
+    }
+  };
+
+  const renderExpirationCell = (dateString?: string | null) => {
+    if (!dateString) {
+      return (
+        <span className="text-sm text-muted-foreground">
+          {t("links.list.no_expiration")}
+        </span>
+      );
+    }
+
+    try {
+      const date = new Date(dateString);
+      const formatted = formatDateTime(dateString);
+      const isExpired = date.getTime() <= Date.now();
+
+      if (!formatted) {
+        return (
+          <span className="text-sm text-muted-foreground">
+            {t("links.list.no_expiration")}
+          </span>
+        );
+      }
+
+      return (
+        <div className="flex flex-col gap-1">
+          <span className="text-sm">{formatted}</span>
+          <Badge
+            variant={isExpired ? "destructive" : "secondary"}
+            className="w-fit text-xs font-medium"
+          >
+            {isExpired
+              ? t("links.list.expired")
+              : t("links.list.expires_badge")}
+          </Badge>
+        </div>
+      );
+    } catch {
+      return (
+        <span className="text-sm text-muted-foreground">
+          {t("links.list.no_expiration")}
+        </span>
+      );
+    }
+  };
+
   const getSortIcon = (field: SortField) => {
     if (field !== sortField) return null;
     return sortOrder === "asc" ? (
@@ -333,6 +394,9 @@ export function LinksList({
                     {t("links.list.created_at")}{" "}
                     {getSortIcon("createdAt")}
                   </TableHead>
+                  <TableHead className="font-semibold">
+                    {t("links.list.expiration")}
+                  </TableHead>
                   <TableHead className="text-right">
                     {t("links.list.actions")}
                   </TableHead>
@@ -375,6 +439,7 @@ export function LinksList({
                     <TableCell className="text-muted-foreground">
                       {formatDate(link.createdAt)}
                     </TableCell>
+                    <TableCell>{renderExpirationCell(link.expiresAt)}</TableCell>
                     <TableCell>
                       <div className="flex items-center justify-end gap-2">
                         <Button

--- a/frontend/src/pages/links/types.ts
+++ b/frontend/src/pages/links/types.ts
@@ -29,6 +29,7 @@ export interface LinkFormData extends UTMParametersType {
   deviceRules: DeviceRule[];
   isPasswordProtected?: boolean;
   password?: string;
+  expiresAt?: string | null;
 }
 
 export type LinkFormProps = {

--- a/frontend/src/pages/types.ts
+++ b/frontend/src/pages/types.ts
@@ -11,6 +11,7 @@ export interface ReferralLink {
   conversionRate?: number;
   createdAt: string;
   updatedAt: string;
+  expiresAt?: string | null;
   rules: GeoRule[];
   deviceRules: DeviceRule[]; // Add this line
   _count?: {

--- a/frontend/src/services/linkService.ts
+++ b/frontend/src/services/linkService.ts
@@ -7,6 +7,7 @@ export interface CreateLinkDTO {
     redirectUrl: string;
     countries: string[];
   }[];
+  expiresAt?: string | null;
 }
 
 interface Link {


### PR DESCRIPTION
## Summary
- add an optional `expiresAt` column for links, update controllers to accept it, and stop redirecting once a link is past its expiry
- extend API DTOs and the link form with a new expiration tab, reusable picker component, and translate strings in English and French
- surface the scheduled expiration state in link previews and the links table so teams can see and clear pending expirations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fe3fc38638832b91bf674792a26af7